### PR TITLE
feat: TripSegment 시스템 구축 및 대중교통 배치 처리 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -46,6 +46,9 @@ dependencies {
     runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.12.5'
     runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.12.5'
 
+    // Redis
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'
 

--- a/src/main/java/com/chocobi/leafy/config/RedisConfig.java
+++ b/src/main/java/com/chocobi/leafy/config/RedisConfig.java
@@ -1,0 +1,22 @@
+package com.chocobi.leafy.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+
+@Configuration
+public class RedisConfig {
+
+    @Bean
+    LettuceConnectionFactory connectionFactory() {
+        return new LettuceConnectionFactory();
+    }
+
+    @Bean
+    public RedisTemplate<String, Object> redisTemplate() {
+        RedisTemplate<String, Object> template = new RedisTemplate<>();
+        template.setConnectionFactory(connectionFactory());
+        return template;
+    }
+}

--- a/src/main/java/com/chocobi/leafy/constants/Transport.java
+++ b/src/main/java/com/chocobi/leafy/constants/Transport.java
@@ -1,0 +1,6 @@
+package com.chocobi.leafy.constants;
+
+public class Transport {
+    public static final String CAR = "자동차";
+    public static final String PUBLIC_TRANS = "대중교통";
+}

--- a/src/main/java/com/chocobi/leafy/distance/controller/DistanceController.java
+++ b/src/main/java/com/chocobi/leafy/distance/controller/DistanceController.java
@@ -1,7 +1,7 @@
 package com.chocobi.leafy.distance.controller;
 
 import com.chocobi.leafy.distance.domain.CarDistanceRequest;
-import com.chocobi.leafy.distance.domain.TransDistanceRequest;
+import com.chocobi.leafy.distance.domain.TransDistanceBatchRequest;
 import com.chocobi.leafy.distance.dto.RouteCalculationResult;
 import com.chocobi.leafy.distance.service.CarDistanceService;
 import com.chocobi.leafy.distance.domain.DistanceResponse;
@@ -30,7 +30,7 @@ public class DistanceController {
     }
 
     @PostMapping("/trans")
-    public List<RouteCalculationResult> getTransDistance(@RequestBody TransDistanceRequest request) {
-        return transDistanceService.getDistance(request);
+    public List<List<RouteCalculationResult>> getTransDistance(@RequestBody TransDistanceBatchRequest request) {
+        return transDistanceService.getDistanceBatch(request);
     }
 }

--- a/src/main/java/com/chocobi/leafy/distance/controller/DistanceController.java
+++ b/src/main/java/com/chocobi/leafy/distance/controller/DistanceController.java
@@ -30,7 +30,7 @@ public class DistanceController {
     }
 
     @PostMapping("/trans")
-    public List<List<RouteCalculationResult>> getTransDistance(@RequestBody TransDistanceBatchRequest request) {
+    public List<RouteCalculationResult> getTransDistance(@RequestBody TransDistanceBatchRequest request) {
         return transDistanceService.getDistanceBatch(request);
     }
 }

--- a/src/main/java/com/chocobi/leafy/distance/domain/CarDistanceRequest.java
+++ b/src/main/java/com/chocobi/leafy/distance/domain/CarDistanceRequest.java
@@ -7,6 +7,7 @@ import java.util.List;
 
 @Data
 public class CarDistanceRequest {
+    private Long tripId;
     private Point origin;
     private Point destination;
     private List<Point> waypoints = new ArrayList<>();

--- a/src/main/java/com/chocobi/leafy/distance/domain/TransDistanceBatchRequest.java
+++ b/src/main/java/com/chocobi/leafy/distance/domain/TransDistanceBatchRequest.java
@@ -1,0 +1,11 @@
+package com.chocobi.leafy.distance.domain;
+
+import lombok.Data;
+
+import java.util.List;
+
+@Data
+public class TransDistanceBatchRequest {
+    private Long tripId;
+    private List<TransDistanceRequest> requests;
+}

--- a/src/main/java/com/chocobi/leafy/distance/dto/Routes.java
+++ b/src/main/java/com/chocobi/leafy/distance/dto/Routes.java
@@ -2,10 +2,12 @@ package com.chocobi.leafy.distance.dto;
 
 import lombok.Data;
 
+import java.util.List;
+
 @Data
 public class Routes {
-
     private Summary summary;
     private Integer result_code;
     private String result_message;
+    private List<Section> sections;
 }

--- a/src/main/java/com/chocobi/leafy/distance/dto/Section.java
+++ b/src/main/java/com/chocobi/leafy/distance/dto/Section.java
@@ -5,4 +5,5 @@ import lombok.Data;
 @Data
 public class Section {
     private int distance;
+    private double carbonEmission;
 }

--- a/src/main/java/com/chocobi/leafy/distance/dto/Section.java
+++ b/src/main/java/com/chocobi/leafy/distance/dto/Section.java
@@ -1,0 +1,8 @@
+package com.chocobi.leafy.distance.dto;
+
+import lombok.Data;
+
+@Data
+public class Section {
+    private int distance;
+}

--- a/src/main/java/com/chocobi/leafy/distance/service/CarDistanceService.java
+++ b/src/main/java/com/chocobi/leafy/distance/service/CarDistanceService.java
@@ -3,12 +3,16 @@ package com.chocobi.leafy.distance.service;
 import com.chocobi.leafy.constants.CarbonEmissionConst;
 import com.chocobi.leafy.constants.DistanceConst;
 import com.chocobi.leafy.constants.Kakao;
+import com.chocobi.leafy.constants.Transport;
 import com.chocobi.leafy.distance.domain.CarDistanceRequest;
 import com.chocobi.leafy.distance.domain.DistanceResponse;
 import com.chocobi.leafy.distance.domain.Point;
 import com.chocobi.leafy.distance.dto.KakaoNaviResponse;
 import com.chocobi.leafy.distance.dto.Routes;
+import com.chocobi.leafy.distance.dto.Section;
 import com.chocobi.leafy.distance.dto.Summary;
+import com.chocobi.leafy.trip.service.TripSegmentService;
+import com.chocobi.leafy.util.CarbonCalculator;
 import org.springframework.stereotype.Service;
 import org.springframework.web.reactive.function.client.WebClient;
 
@@ -20,9 +24,11 @@ import java.util.Map;
 public class CarDistanceService {
 
     private final WebClient kakaoNaviWebClient;
+    private final TripSegmentService tripSegmentService;
 
-    public CarDistanceService(WebClient kakaoNaviWebClient) {
+    public CarDistanceService(WebClient kakaoNaviWebClient, TripSegmentService tripSegmentService) {
         this.kakaoNaviWebClient = kakaoNaviWebClient;
+        this.tripSegmentService = tripSegmentService;
     }
 
     /**
@@ -64,6 +70,7 @@ public class CarDistanceService {
             throw new RuntimeException("카카오 네비 API 에러 (코드: " + errorCode + ", 메시지: " + errorMsg + ")");
         }
 
+        // summary 꺼내기
         Summary summary = routes.getSummary();
 
         if (summary == null) {
@@ -73,13 +80,36 @@ public class CarDistanceService {
         // summary의 distance와 duration 꺼내기
         int distance = summary.getDistance();
         int duration = summary.getDuration();
-        double carbonEmission = distance / 1000.0 * CarbonEmissionConst.CAR_EMISSION;
+        double carbonEmission = CarbonCalculator.CalculateCarCarbonEmission(distance);
+
+        // section 꺼내기
+        List<Section> sections = routes.getSections();
+        // waypoint 별 거리 구하기
+        List<Integer> waypointsDistance = getWaypointsDistance(sections);
+
+        tripSegmentService.completeTempTripSegments(request.getTripId(), sections, Transport.CAR);
 
         return new DistanceResponse(distance, duration, carbonEmission);
     }
 
     /**
-     * 구간별 거리, 시간 계산
+     * 출발지, 목적지와 웨이포인트를 리스트에 담기
+     * @param request
+     */
+    private static List<Point> buildAllPoints(CarDistanceRequest request) {
+        // 전체 경로 점들 (origin + waypoints + destination)
+        List<Point> allPoints = new ArrayList<>();
+        allPoints.add(request.getOrigin());
+        if (request.getWaypoints() != null) {
+            allPoints.addAll(request.getWaypoints());
+        }
+        allPoints.add(request.getDestination());
+
+        return allPoints;
+    }
+
+    /**
+     * api 호출 에러 시, 구간별 거리, 시간 계산
      * @param request
      * @return
      */
@@ -90,12 +120,7 @@ public class CarDistanceService {
         double totalDuration = 0;
 
         // 전체 경로 점들 (origin + waypoints + destination)
-        List<Point> allPoints = new ArrayList<>();
-        allPoints.add(request.getOrigin());
-        if (request.getWaypoints() != null) {
-            allPoints.addAll(request.getWaypoints());
-        }
-        allPoints.add(request.getDestination());
+        List<Point> allPoints = buildAllPoints(request);
 
         // 각 구간별로 계산
         for (int i = 0; i < allPoints.size() - 1; i++) {
@@ -153,5 +178,17 @@ public class CarDistanceService {
         double c = 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1-a));
 
         return R * c;
+    }
+
+    /**
+     * 웨이포인트 별 거리 구하기
+     */
+    private List<Integer> getWaypointsDistance(List<Section> sections) {
+        List<Integer> waypointDistance = new ArrayList<>();
+        sections.forEach(section -> {
+            waypointDistance.add(section.getDistance());
+        });
+
+        return waypointDistance;
     }
 }

--- a/src/main/java/com/chocobi/leafy/distance/service/CarDistanceService.java
+++ b/src/main/java/com/chocobi/leafy/distance/service/CarDistanceService.java
@@ -84,8 +84,10 @@ public class CarDistanceService {
 
         // section 꺼내기
         List<Section> sections = routes.getSections();
-        // waypoint 별 거리 구하기
-        List<Integer> waypointsDistance = getWaypointsDistance(sections);
+        for (Section section : sections) {
+            double sectionCarbonEmission = CarbonCalculator.CalculateCarCarbonEmission(section.getDistance());
+            section.setCarbonEmission(sectionCarbonEmission);
+        }
 
         tripSegmentService.completeTempTripSegments(request.getTripId(), sections, Transport.CAR);
 
@@ -155,7 +157,7 @@ public class CarDistanceService {
             }
         }
 
-        double carbonEmission = totalDistance / 1000.0 * CarbonEmissionConst.CAR_EMISSION;
+        double carbonEmission = CarbonCalculator.CalculateCarCarbonEmission(totalDistance);
         System.out.println("구간별 계산 완료 - 총 거리: " + totalDistance + "m, 총 시간: " + totalDuration + "s, 탄소배출량: " + carbonEmission + "g");
 
         return new DistanceResponse(totalDistance, (int) totalDuration, carbonEmission);
@@ -178,17 +180,5 @@ public class CarDistanceService {
         double c = 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1-a));
 
         return R * c;
-    }
-
-    /**
-     * 웨이포인트 별 거리 구하기
-     */
-    private List<Integer> getWaypointsDistance(List<Section> sections) {
-        List<Integer> waypointDistance = new ArrayList<>();
-        sections.forEach(section -> {
-            waypointDistance.add(section.getDistance());
-        });
-
-        return waypointDistance;
     }
 }

--- a/src/main/java/com/chocobi/leafy/distance/service/TransDistanceService.java
+++ b/src/main/java/com/chocobi/leafy/distance/service/TransDistanceService.java
@@ -3,6 +3,7 @@ package com.chocobi.leafy.distance.service;
 import com.chocobi.leafy.constants.CarbonEmissionConst;
 import com.chocobi.leafy.constants.DistanceConst;
 import com.chocobi.leafy.constants.TmapPathTypeConst;
+import com.chocobi.leafy.distance.domain.TransDistanceBatchRequest;
 import com.chocobi.leafy.distance.domain.TransDistanceRequest;
 import com.chocobi.leafy.distance.dto.*;
 import com.chocobi.leafy.util.CarbonCalculator;
@@ -20,6 +21,28 @@ public class TransDistanceService {
 
     public TransDistanceService(WebClient tmapWebClient) {
         this.tmapWebClient = tmapWebClient;
+    }
+
+    /**
+     * 한 번의 요청으로 모든 경유지 길찾기 실행
+     * @param batchRequest
+     * @return
+     */
+    public List<List<RouteCalculationResult>> getDistanceBatch(TransDistanceBatchRequest batchRequest) {
+        List<List<RouteCalculationResult>> results = new ArrayList<>();
+
+        for (TransDistanceRequest request : batchRequest.getRequests()) {
+            try {
+                List<RouteCalculationResult> result = getDistance(request);
+                results.add(result);
+            } catch (Exception e) {
+                // 실패할 경우 빈 리스트 추가 (또는 에러 정보)
+                System.err.println("경로 계산 실패: " + request + ", 에러: " + e.getMessage());
+                results.add(new ArrayList<>());
+            }
+        }
+
+        return results;
     }
 
     /**

--- a/src/main/java/com/chocobi/leafy/distance/service/TransDistanceService.java
+++ b/src/main/java/com/chocobi/leafy/distance/service/TransDistanceService.java
@@ -3,9 +3,11 @@ package com.chocobi.leafy.distance.service;
 import com.chocobi.leafy.constants.CarbonEmissionConst;
 import com.chocobi.leafy.constants.DistanceConst;
 import com.chocobi.leafy.constants.TmapPathTypeConst;
+import com.chocobi.leafy.constants.Transport;
 import com.chocobi.leafy.distance.domain.TransDistanceBatchRequest;
 import com.chocobi.leafy.distance.domain.TransDistanceRequest;
 import com.chocobi.leafy.distance.dto.*;
+import com.chocobi.leafy.trip.service.TripSegmentService;
 import com.chocobi.leafy.util.CarbonCalculator;
 import org.springframework.stereotype.Service;
 import org.springframework.web.reactive.function.client.WebClient;
@@ -18,9 +20,11 @@ import java.util.List;
 public class TransDistanceService {
 
     private final WebClient tmapWebClient;
+    private final TripSegmentService tripSegmentService;
 
-    public TransDistanceService(WebClient tmapWebClient) {
+    public TransDistanceService(WebClient tmapWebClient, TripSegmentService tripSegmentService) {
         this.tmapWebClient = tmapWebClient;
+        this.tripSegmentService = tripSegmentService;
     }
 
     /**
@@ -28,19 +32,28 @@ public class TransDistanceService {
      * @param batchRequest
      * @return
      */
-    public List<List<RouteCalculationResult>> getDistanceBatch(TransDistanceBatchRequest batchRequest) {
-        List<List<RouteCalculationResult>> results = new ArrayList<>();
+    public List<RouteCalculationResult> getDistanceBatch(TransDistanceBatchRequest batchRequest) {
+        List<RouteCalculationResult> results = new ArrayList<>();
+        List<Section> sections = new ArrayList<>();
 
         for (TransDistanceRequest request : batchRequest.getRequests()) {
             try {
                 List<RouteCalculationResult> result = getDistance(request);
-                results.add(result);
+                RouteCalculationResult bestRoute = result.getFirst(); // 최적 경로 뽑기
+                results.add(bestRoute);
+
+                Section section = new Section();
+                section.setDistance((int)bestRoute.getTotalDistance());
+                section.setCarbonEmission(bestRoute.getCarbonEmission());
+                sections.add(section);
+
             } catch (Exception e) {
-                // 실패할 경우 빈 리스트 추가 (또는 에러 정보)
                 System.err.println("경로 계산 실패: " + request + ", 에러: " + e.getMessage());
-                results.add(new ArrayList<>());
+                throw new RuntimeException("일부 구간 계산 실패로 인한 전체 배치 실패", e);
             }
         }
+
+        tripSegmentService.completeTempTripSegments(batchRequest.getTripId(), sections, Transport.PUBLIC_TRANS);
 
         return results;
     }

--- a/src/main/java/com/chocobi/leafy/distance/service/TransDistanceService.java
+++ b/src/main/java/com/chocobi/leafy/distance/service/TransDistanceService.java
@@ -5,6 +5,7 @@ import com.chocobi.leafy.constants.DistanceConst;
 import com.chocobi.leafy.constants.TmapPathTypeConst;
 import com.chocobi.leafy.distance.domain.TransDistanceRequest;
 import com.chocobi.leafy.distance.dto.*;
+import com.chocobi.leafy.util.CarbonCalculator;
 import org.springframework.stereotype.Service;
 import org.springframework.web.reactive.function.client.WebClient;
 
@@ -95,7 +96,7 @@ public class TransDistanceService {
                 int totalSubwayDistance = totalDistance - totalWalkDistance - result.getBusDistance() - result.getTrainDistance();
                 result.setSubwayDistance(Math.max(0, totalSubwayDistance));
 
-                double carbonEmission = (result.getSubwayDistance() / 1000.0) * CarbonEmissionConst.SUBWAY_EMISSION + (result.getTrainDistance() / 1000.0) * CarbonEmissionConst.TRAIN_EMISSION + (result.getBusDistance() / 1000.0) * CarbonEmissionConst.BUS_EMISSION;
+                double carbonEmission = CarbonCalculator.CalculatePublicTransCarbonEmission(result.getSubwayDistance(), result.getTrainDistance(), result.getBusDistance());
                 result.setCarbonEmission(carbonEmission);
 
                 finalResults.add(result);

--- a/src/main/java/com/chocobi/leafy/place/entity/Place.java
+++ b/src/main/java/com/chocobi/leafy/place/entity/Place.java
@@ -6,12 +6,18 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.io.Serial;
+import java.io.Serializable;
+
 @Entity
 @AllArgsConstructor
 @NoArgsConstructor
 @Getter
 @Builder
-public class Place {
+public class Place implements Serializable {
+    
+    @Serial
+    private static final long serialVersionUID = 1L;
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;

--- a/src/main/java/com/chocobi/leafy/trip/entity/Trip.java
+++ b/src/main/java/com/chocobi/leafy/trip/entity/Trip.java
@@ -7,6 +7,8 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.io.Serial;
+import java.io.Serializable;
 import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
@@ -16,7 +18,10 @@ import java.util.List;
 @NoArgsConstructor
 @Builder
 @Getter
-public class Trip {
+public class Trip implements Serializable {
+    
+    @Serial
+    private static final long serialVersionUID = 1L;
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;

--- a/src/main/java/com/chocobi/leafy/trip/entity/TripSegment.java
+++ b/src/main/java/com/chocobi/leafy/trip/entity/TripSegment.java
@@ -4,6 +4,8 @@ import com.chocobi.leafy.place.entity.Place;
 import jakarta.persistence.*;
 import lombok.*;
 
+import java.io.Serial;
+import java.io.Serializable;
 import java.time.LocalDateTime;
 
 @Entity
@@ -11,7 +13,10 @@ import java.time.LocalDateTime;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Builder
 @AllArgsConstructor
-public class TripSegment {
+public class TripSegment implements Serializable {
+
+    @Serial
+    private static final long serialVersionUID = 1L;
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/chocobi/leafy/trip/entity/TripSegment.java
+++ b/src/main/java/com/chocobi/leafy/trip/entity/TripSegment.java
@@ -2,22 +2,24 @@ package com.chocobi.leafy.trip.entity;
 
 import com.chocobi.leafy.place.entity.Place;
 import jakarta.persistence.*;
-import lombok.AccessLevel;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
+
+import java.time.LocalDateTime;
 
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Builder
+@AllArgsConstructor
 public class TripSegment {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-//    @ManyToOne
-//    @JoinColumn(name = "trip_id")
-//    private Trip trip;
+    @ManyToOne
+    @JoinColumn(name = "trip_id")
+    private Trip trip;
 
     @ManyToOne
     @JoinColumn(name = "start_place_id")
@@ -29,9 +31,26 @@ public class TripSegment {
 
     private String transport;
 
+    private double distance;
+
     @Column(name = "carbon_emitted")
     private double carbonEmitted;
 
     @Column(name = "carbon_saved")
     private double carbonSaved;
+
+    @Column(name = "created_at")
+    private LocalDateTime createdAt;
+
+    @Column(name = "updated_at")
+    private LocalDateTime updatedAt;
+
+    /**
+     * data insert 직전에 실행되는 어노테이션
+     */
+    @PrePersist
+    public void creatTime() {
+        this.createdAt = LocalDateTime.now();
+        this.updatedAt = LocalDateTime.now();
+    }
 }

--- a/src/main/java/com/chocobi/leafy/trip/repository/TripSegmentRepository.java
+++ b/src/main/java/com/chocobi/leafy/trip/repository/TripSegmentRepository.java
@@ -1,0 +1,9 @@
+package com.chocobi.leafy.trip.repository;
+
+import com.chocobi.leafy.trip.entity.TripSegment;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface TripSegmentRepository extends JpaRepository<TripSegment, Long> {
+}

--- a/src/main/java/com/chocobi/leafy/trip/repository/TripSegmentRepository.java
+++ b/src/main/java/com/chocobi/leafy/trip/repository/TripSegmentRepository.java
@@ -4,6 +4,9 @@ import com.chocobi.leafy.trip.entity.TripSegment;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
+
 @Repository
 public interface TripSegmentRepository extends JpaRepository<TripSegment, Long> {
+    List<TripSegment> findByTrip_Id(Long tripId);
 }

--- a/src/main/java/com/chocobi/leafy/trip/service/TripSegmentService.java
+++ b/src/main/java/com/chocobi/leafy/trip/service/TripSegmentService.java
@@ -51,6 +51,7 @@ public class TripSegmentService {
             TripPlaceResponse startPlace = mutableTripPlaces.get(i);
             TripPlaceResponse endPlace = mutableTripPlaces.get(i + 1);
             double distance = sections.get(i).getDistance();
+            double carbonEmission = sections.get(i).getCarbonEmission();
 
             TripSegment tripSegment = TripSegment.builder()
                     .trip(Trip.builder().id(tripId).build())
@@ -58,7 +59,7 @@ public class TripSegmentService {
                     .endPlaceId(Place.builder().id(endPlace.getPlaceId()).build())
                     .transport(transport)
                     .distance(distance)
-                    .carbonEmitted(CarbonCalculator.CalculateCarCarbonEmission(distance))
+                    .carbonEmitted(carbonEmission)
                     .carbonSaved(0)
                     .build();
             tripSegments.add(tripSegment);

--- a/src/main/java/com/chocobi/leafy/trip/service/TripSegmentService.java
+++ b/src/main/java/com/chocobi/leafy/trip/service/TripSegmentService.java
@@ -1,0 +1,131 @@
+package com.chocobi.leafy.trip.service;
+
+import com.chocobi.leafy.distance.dto.Section;
+import com.chocobi.leafy.place.entity.Place;
+import com.chocobi.leafy.trip.dto.TripPlaceResponse;
+import com.chocobi.leafy.trip.entity.Trip;
+import com.chocobi.leafy.trip.entity.TripSegment;
+import com.chocobi.leafy.trip.repository.TripSegmentRepository;
+import com.chocobi.leafy.util.CarbonCalculator;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class TripSegmentService {
+    private final TripSegmentRepository tripSegmentRepository;
+    private final TripService tripService;
+    private final RedisTemplate<String, Object> redisTemplate;
+
+    /**
+     * TripSegments를 만들고 임시 저장하는 편의 통합 메서드
+     * @param tripId
+     * @param sections
+     * @param transport
+     */
+    public void completeTempTripSegments(Long tripId, List<Section> sections, String transport) {
+        List<TripSegment> tripSegments = createTripSegments(tripId, sections, transport);
+        saveTempTripSegments(tripSegments);
+    }
+
+    /**
+     * 트립 세그먼트 만들기
+     * @param tripId 트립 아이디
+     * @param sections 구간별 거리 정보 담김
+     * @param transport 교통 수단
+     * @return
+     */
+    public List<TripSegment> createTripSegments(Long tripId, List<Section> sections, String transport) {
+        List<TripPlaceResponse> tripPlaces = tripService.getTripPlaces(tripId);
+        List<TripSegment> tripSegments = new ArrayList<>();
+
+        // visit_order 순서로 정렬
+        tripPlaces.sort(Comparator.comparing(TripPlaceResponse::getVisitOrder));
+
+        for (int i = 0; i < sections.size(); i++) {
+            TripPlaceResponse startPlace = tripPlaces.get(i);
+            TripPlaceResponse endPlace = tripPlaces.get(i + 1);
+            double distance = sections.get(i).getDistance();
+
+            TripSegment tripSegment = TripSegment.builder()
+                    .trip(Trip.builder().id(tripId).build())
+                    .startPlaceId(Place.builder().id(startPlace.getPlaceId()).build())
+                    .endPlaceId(Place.builder().id(endPlace.getPlaceId()).build())
+                    .transport(transport)
+                    .distance(distance)
+                    .carbonEmitted(CarbonCalculator.CalculateCarCarbonEmission(distance))
+                    .carbonSaved(0)
+                    .build();
+            tripSegments.add(tripSegment);
+        }
+
+        return tripSegments;
+    }
+
+    /**
+     * Redis에 TripSegments 임시 저장
+     * @param tripSegments
+     * @return
+     */
+    public Long saveTempTripSegments(List<TripSegment> tripSegments) {
+
+        if (tripSegments == null || tripSegments.isEmpty()) {
+            throw new IllegalArgumentException("TripSegments가 비어있습니다.");
+        }
+
+        Long tripId = tripSegments.getFirst().getTrip().getId();
+        String key = "temp_trip_segments:" + tripId;
+        redisTemplate.opsForValue().set(key, tripSegments);
+        redisTemplate.expire(key, 30, java.util.concurrent.TimeUnit.MINUTES); // 만료시간 30분
+
+        return tripId;
+    }
+
+    /**
+     * 임시 TripSegments를 DB에 저장하고 Redis에서 삭제하는 편의 통합 메서드
+     * @param tripId
+     */
+    public void completeTripSegments(Long tripId) {
+        List<TripSegment> tripSegments = getTempTripSegments(tripId); // 임시 TripSegments를 불러와서
+        saveTripSegments(tripSegments); // DB에 저장
+        deleteTempTripSegments(tripId); // 임시 저장한 TripSegments를 삭제
+    }
+
+    /**
+     * Redis에서 임시 TripSegments 가져오기
+     * @param tripId
+     * @return
+     */
+    public List<TripSegment> getTempTripSegments(Long tripId) {
+        String key = "temp_trip_segments:" + tripId;
+        Object result = redisTemplate.opsForValue().get(key);
+
+        if (result == null) {
+            throw new IllegalArgumentException("임시 저장된 TripSegments가 없습니다. tripId: " + tripId);
+        }
+
+        return (List<TripSegment>) result;
+    }
+
+    /**
+     * Redis에서 TripSegments 삭제
+     * @param tripId
+     */
+    public void deleteTempTripSegments(Long tripId) {
+        String key = "temp_trip_segments:" + tripId;
+        redisTemplate.delete(key);
+    }
+
+    /**
+     * DB에 TripSegment 저장
+     * @param tripSegments
+     */
+    public void saveTripSegments(List<TripSegment> tripSegments) {
+        tripSegmentRepository.saveAll(tripSegments);
+    }
+}

--- a/src/main/java/com/chocobi/leafy/trip/service/TripSegmentService.java
+++ b/src/main/java/com/chocobi/leafy/trip/service/TripSegmentService.java
@@ -44,12 +44,12 @@ public class TripSegmentService {
         List<TripPlaceResponse> tripPlaces = tripService.getTripPlaces(tripId);
         List<TripSegment> tripSegments = new ArrayList<>();
 
-        // visit_order 순서로 정렬
-        tripPlaces.sort(Comparator.comparing(TripPlaceResponse::getVisitOrder));
+        List<TripPlaceResponse> mutableTripPlaces = new ArrayList<>(tripPlaces);
+        mutableTripPlaces.sort(Comparator.comparing(TripPlaceResponse::getVisitOrder));
 
         for (int i = 0; i < sections.size(); i++) {
-            TripPlaceResponse startPlace = tripPlaces.get(i);
-            TripPlaceResponse endPlace = tripPlaces.get(i + 1);
+            TripPlaceResponse startPlace = mutableTripPlaces.get(i);
+            TripPlaceResponse endPlace = mutableTripPlaces.get(i + 1);
             double distance = sections.get(i).getDistance();
 
             TripSegment tripSegment = TripSegment.builder()

--- a/src/main/java/com/chocobi/leafy/util/CarbonCalculator.java
+++ b/src/main/java/com/chocobi/leafy/util/CarbonCalculator.java
@@ -1,0 +1,14 @@
+package com.chocobi.leafy.util;
+
+import com.chocobi.leafy.constants.CarbonEmissionConst;
+
+public class CarbonCalculator {
+
+    public static double CalculateCarCarbonEmission(double distance) {
+        return distance / 1000.0 * CarbonEmissionConst.CAR_EMISSION;
+    }
+
+    public static double CalculatePublicTransCarbonEmission(double subwayDistance, double trainDistance, double busDistance ){
+        return (subwayDistance / 1000.0) * CarbonEmissionConst.SUBWAY_EMISSION + (trainDistance / 1000.0) * CarbonEmissionConst.TRAIN_EMISSION + (busDistance / 1000.0) * CarbonEmissionConst.BUS_EMISSION;
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -14,3 +14,7 @@ spring.jpa.properties.hibernate.format_sql=true
 spring.jpa.hibernate.ddl-auto=create
 
 spring.jpa.database-platform=org.hibernate.dialect.MySQLDialect
+
+# Redis ??
+spring.data.redis.host=localhost
+spring.data.redis.port=6379

--- a/src/test/java/com/chocobi/leafy/trip/service/TripSegmentServiceCarTest.java
+++ b/src/test/java/com/chocobi/leafy/trip/service/TripSegmentServiceCarTest.java
@@ -17,6 +17,7 @@ import org.springframework.data.redis.core.ValueOperations;
 import java.util.Arrays;
 import java.util.List;
 
+import static java.util.concurrent.TimeUnit.MINUTES;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
@@ -122,6 +123,66 @@ class TripSegmentServiceCarTest {
         assertEquals(1L, result);
         verify(redisTemplate).opsForValue();
         verify(valueOperations).set("temp_trip_segments:1", segments);
-        verify(redisTemplate).expire("temp_trip_segments:1", 30, java.util.concurrent.TimeUnit.MINUTES);
+        verify(redisTemplate).expire("temp_trip_segments:1", 30, MINUTES);
+    }
+
+    @Test
+    public void 임시_통합_테스트() throws Exception {
+        // given
+        Long tripId = 1L;
+        String transport = Transport.CAR;
+
+        TripPlaceResponse place1 = TripPlaceResponse.builder()
+                .placeId(10L)
+                .visitOrder(1)
+                .build();
+
+        TripPlaceResponse place2 = TripPlaceResponse.builder()
+                .placeId(20L)
+                .visitOrder(2)
+                .build();
+
+        TripPlaceResponse place3 = TripPlaceResponse.builder()
+                .placeId(30L)
+                .visitOrder(3)
+                .build();
+
+        List<TripPlaceResponse> places = Arrays.asList(place1, place2, place3);
+
+        Section section1 = new Section();
+        section1.setDistance(1000);
+
+        Section section2 = new Section();
+        section2.setDistance(2000);
+
+        List<Section> sections = Arrays.asList(section1, section2);
+
+        when(tripService.getTripPlaces(tripId)).thenReturn(places);
+        ValueOperations<String, Object> valueOperations = mock(ValueOperations.class);
+        when(redisTemplate.opsForValue()).thenReturn(valueOperations);
+
+        // when
+        tripSegmentService.completeTempTripSegments(tripId, sections, transport);
+
+        // then
+        verify(tripService).getTripPlaces(tripId);
+        verify(valueOperations).set(eq("temp_trip_segments:1"), anyList());
+        verify(redisTemplate).expire("temp_trip_segments:1", 30, MINUTES);
+    }
+
+    @Test
+    public void Redis에서_임시데이터_조회() throws Exception {
+        // given
+        List<TripSegment> segments = Arrays.asList();
+        ValueOperations<String, Object> valueOperations = mock(ValueOperations.class);
+        when(redisTemplate.opsForValue()).thenReturn(valueOperations);
+        when(valueOperations.get("temp_trip_segments:1")).thenReturn(segments);
+
+        // when
+        List<TripSegment> result = tripSegmentService.getTempTripSegments(1L);
+
+        // then
+        assertEquals(segments, result);
+        verify(valueOperations).get("temp_trip_segments:1");
     }
 }

--- a/src/test/java/com/chocobi/leafy/trip/service/TripSegmentServiceCarTest.java
+++ b/src/test/java/com/chocobi/leafy/trip/service/TripSegmentServiceCarTest.java
@@ -61,9 +61,11 @@ class TripSegmentServiceCarTest {
 
         Section section1 = new Section();
         section1.setDistance(1000);
+        section1.setCarbonEmission(210.0);
 
         Section section2 = new Section();
         section2.setDistance(2000);
+        section2.setCarbonEmission(420.0);
 
         List<Section> sections = Arrays.asList(section1, section2);
 
@@ -77,6 +79,7 @@ class TripSegmentServiceCarTest {
         TripSegment segment1 = result.getFirst();
         assertEquals(Transport.CAR, segment1.getTransport());
         assertEquals(1000, segment1.getDistance());
+        System.out.println(segment1.getCarbonEmitted());
         assertEquals(210.0, segment1.getCarbonEmitted());
         assertEquals(0, segment1.getCarbonSaved());
         assertEquals(10L, segment1.getStartPlaceId().getId());

--- a/src/test/java/com/chocobi/leafy/trip/service/TripSegmentServiceIntegrationTest.java
+++ b/src/test/java/com/chocobi/leafy/trip/service/TripSegmentServiceIntegrationTest.java
@@ -1,0 +1,121 @@
+package com.chocobi.leafy.trip.service;
+
+import com.chocobi.leafy.constants.Transport;
+import com.chocobi.leafy.distance.dto.Section;
+import com.chocobi.leafy.place.entity.Place;
+import com.chocobi.leafy.place.repository.PlaceRepository;
+import com.chocobi.leafy.place.service.PlaceService;
+import com.chocobi.leafy.trip.dto.TripPlaceListRequest;
+import com.chocobi.leafy.trip.dto.TripPlaceRequest;
+import com.chocobi.leafy.trip.dto.TripRequest;
+import com.chocobi.leafy.trip.entity.TripSegment;
+import com.chocobi.leafy.trip.repository.TripSegmentRepository;
+import com.chocobi.leafy.user.entity.User;
+import com.chocobi.leafy.user.service.UserService;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@SpringBootTest
+@Transactional
+class TripSegmentServiceIntegrationTest {
+
+    @Autowired
+    private TripSegmentService tripSegmentService;
+
+    @Autowired
+    private TripService tripService;
+
+    @Autowired
+    private UserService userService;
+
+    @Autowired
+    private PlaceRepository placeRepository;
+
+    @Autowired
+    private TripSegmentRepository tripSegmentRepository;
+
+    @Autowired
+    private RedisTemplate<String, Object> redisTemplate;
+    
+    @Test
+    public void 실제_환경에서_TripSegment_생성_및_Redis_저장_테스트() throws Exception {
+        // given
+        User user = userService.saveOrGetUser(12345L, "통합 테스트 유저", null);
+
+        Place place1 = Place.builder()
+                .title("서울역")
+                .latitude(37.5547)
+                .longitude(126.9706)
+                .address("서울 중구 세종대로")
+                .build();
+        placeRepository.save(place1);
+
+        Place place2 = Place.builder()
+                .title("부산역")
+                .latitude(35.1156)
+                .longitude(129.0403)
+                .address("부산 동구 중앙대로")
+                .build();
+        placeRepository.save(place2);
+
+        TripRequest tripRequest = new TripRequest();
+        tripRequest.setUser_id(user.getKakaoId());
+        tripRequest.setTitle("통합 테스트 여행");
+        tripRequest.setStart_date(LocalDate.now());
+        tripRequest.setEnd_date(LocalDate.now().plusDays(3));
+
+        Long tripId = tripService.createTrip(tripRequest);
+
+        TripPlaceRequest placeReq1 = new TripPlaceRequest();
+        placeReq1.setPlaceId(place1.getId());
+        placeReq1.setVisitOrder(1);
+        placeReq1.setVisitDate(LocalDate.now());
+
+        TripPlaceRequest placeReq2 = new TripPlaceRequest();
+        placeReq2.setPlaceId(place2.getId());
+        placeReq2.setVisitOrder(2);
+        placeReq2.setVisitDate(LocalDate.now());
+
+        TripPlaceListRequest listRequest = new TripPlaceListRequest();
+        listRequest.setTripId(tripId);
+        listRequest.setPlaceList(Arrays.asList(placeReq1, placeReq2));
+
+        tripService.saveTripPlace(listRequest);
+
+        Section section = new Section();
+        section.setDistance(50000); // 50km
+        List<Section> sections = Arrays.asList(section);
+
+        // when
+        tripSegmentService.completeTempTripSegments(tripId, sections, Transport.CAR);
+        tripSegmentService.completeTripSegments(tripId);
+
+        // then
+        List<TripSegment> savedSegments = tripSegmentRepository.findAll();
+        assertFalse(savedSegments.isEmpty(), "DB에 TripSegment가 저장되어 있어야 함");
+        assertEquals(1, savedSegments.size(), "1개의 구간이 저장되어 있어야 함");
+
+        TripSegment savedSegment = savedSegments.get(0);
+        assertEquals(Transport.CAR, savedSegment.getTransport());
+        assertEquals(50000, savedSegment.getDistance());
+        assertEquals(10500, savedSegment.getCarbonEmitted());
+        assertEquals(0, savedSegment.getCarbonSaved());
+        assertEquals(place1.getId(), savedSegment.getStartPlaceId().getId());
+        assertEquals(place2.getId(), savedSegment.getEndPlaceId().getId());
+        assertEquals(tripId, savedSegment.getTrip().getId());
+
+        String redisKey = "temp_trip_segments:" + tripId;
+        Object deleteData = redisTemplate.opsForValue().get(redisKey);
+        assertNull(deleteData, "임시 데이터가 삭제되었어야 함");
+    }
+}

--- a/src/test/java/com/chocobi/leafy/trip/service/TripSegmentServiceIntegrationTest.java
+++ b/src/test/java/com/chocobi/leafy/trip/service/TripSegmentServiceIntegrationTest.java
@@ -94,6 +94,7 @@ class TripSegmentServiceIntegrationTest {
 
         Section section = new Section();
         section.setDistance(50000); // 50km
+        section.setCarbonEmission(10500.0);
         List<Section> sections = Arrays.asList(section);
 
         // when

--- a/src/test/java/com/chocobi/leafy/trip/service/TripSegmentServiceTest.java
+++ b/src/test/java/com/chocobi/leafy/trip/service/TripSegmentServiceTest.java
@@ -3,6 +3,7 @@ package com.chocobi.leafy.trip.service;
 import com.chocobi.leafy.constants.Transport;
 import com.chocobi.leafy.distance.dto.Section;
 import com.chocobi.leafy.trip.dto.TripPlaceResponse;
+import com.chocobi.leafy.trip.entity.Trip;
 import com.chocobi.leafy.trip.entity.TripSegment;
 import com.chocobi.leafy.trip.repository.TripSegmentRepository;
 import org.junit.jupiter.api.Test;
@@ -11,6 +12,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
 
 import java.util.Arrays;
 import java.util.List;
@@ -90,5 +92,36 @@ class TripSegmentServiceCarTest {
         assertEquals(1L, segment2.getTrip().getId());
 
         verify(tripService, times(1)).getTripPlaces(1L);
+    }
+
+    @Test
+    void Redis_임시_저장_테스트() {
+        // given
+        TripSegment segment1 = TripSegment.builder()
+                .trip(Trip.builder().id(1L).build())
+                .distance(1000)
+                .transport(Transport.CAR)
+                .build();
+
+        TripSegment segment2 = TripSegment.builder()
+                .trip(Trip.builder().id(1L).build())
+                .distance(2000)
+                .transport(Transport.CAR)
+                .build();
+
+        List<TripSegment> segments = Arrays.asList(segment1, segment2);
+
+        // RedisTemplate의 opsForValue() Mock 설정
+        ValueOperations<String, Object> valueOperations = mock(ValueOperations.class);
+        when(redisTemplate.opsForValue()).thenReturn(valueOperations);
+
+        // when
+        Long result = tripSegmentService.saveTempTripSegments(segments);
+
+        // then
+        assertEquals(1L, result);
+        verify(redisTemplate).opsForValue();
+        verify(valueOperations).set("temp_trip_segments:1", segments);
+        verify(redisTemplate).expire("temp_trip_segments:1", 30, java.util.concurrent.TimeUnit.MINUTES);
     }
 }

--- a/src/test/java/com/chocobi/leafy/trip/service/TripSegmentServiceTest.java
+++ b/src/test/java/com/chocobi/leafy/trip/service/TripSegmentServiceTest.java
@@ -1,0 +1,94 @@
+package com.chocobi.leafy.trip.service;
+
+import com.chocobi.leafy.constants.Transport;
+import com.chocobi.leafy.distance.dto.Section;
+import com.chocobi.leafy.trip.dto.TripPlaceResponse;
+import com.chocobi.leafy.trip.entity.TripSegment;
+import com.chocobi.leafy.trip.repository.TripSegmentRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.redis.core.RedisTemplate;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class TripSegmentServiceCarTest {
+
+    @Mock
+    private TripSegmentRepository tripSegmentRepository;
+
+    @Mock
+    private TripService tripService;
+
+    @Mock
+    private RedisTemplate<String, Object> redisTemplate;
+
+    @InjectMocks
+    private TripSegmentService tripSegmentService;
+
+    @Test
+    void 트립세그먼트_정상_생성_테스트() {
+        // given
+        Long tripId = 1L;
+        String transport = Transport.CAR;
+
+        TripPlaceResponse place1 = TripPlaceResponse.builder()
+                .placeId(10L)
+                .visitOrder(1)
+                .build();
+
+        TripPlaceResponse place2 = TripPlaceResponse.builder()
+                .placeId(20L)
+                .visitOrder(2)
+                .build();
+
+        TripPlaceResponse place3 = TripPlaceResponse.builder()
+                .placeId(30L)
+                .visitOrder(3)
+                .build();
+
+        List<TripPlaceResponse> places = Arrays.asList(place1, place2, place3);
+
+        Section section1 = new Section();
+        section1.setDistance(1000);
+
+        Section section2 = new Section();
+        section2.setDistance(2000);
+
+        List<Section> sections = Arrays.asList(section1, section2);
+
+        // mock 동작 정의
+        when(tripService.getTripPlaces(tripId)).thenReturn(places);
+
+        // when
+        List<TripSegment> result = tripSegmentService.createTripSegments(tripId, sections, transport);
+
+        // then
+        TripSegment segment1 = result.getFirst();
+        assertEquals(Transport.CAR, segment1.getTransport());
+        assertEquals(1000, segment1.getDistance());
+        assertEquals(210.0, segment1.getCarbonEmitted());
+        assertEquals(0, segment1.getCarbonSaved());
+        assertEquals(10L, segment1.getStartPlaceId().getId());
+        assertEquals(20L, segment1.getEndPlaceId().getId());
+        assertEquals(1L, segment1.getTrip().getId());
+
+        TripSegment segment2 = result.get(1);
+        assertEquals(Transport.CAR, segment2.getTransport());
+        assertEquals(2000, segment2.getDistance());
+        assertEquals(420.0, segment2.getCarbonEmitted());
+        assertEquals(0, segment2.getCarbonSaved());
+        assertEquals(20L, segment2.getStartPlaceId().getId());
+        assertEquals(30L, segment2.getEndPlaceId().getId());
+        assertEquals(1L, segment2.getTrip().getId());
+
+        verify(tripService, times(1)).getTripPlaces(1L);
+    }
+}


### PR DESCRIPTION
 ## 🎯 Summary
  여행 구간별 탄소배출량을 저장하는 TripSegment 시스템을 구축하고, 대중교통 배치 처리 API를 추가했습니다.

  ## 🚀 Changes
  ### ✨ TripSegment 시스템 구축
  - **TripSegment 엔티티, 서비스, 레포지토리 추가**
  - **Redis 기반 임시저장 → DB 영구저장 플로우 구현**
  - **자동차/대중교통 Distance API와 연동하여 구간별 데이터 자동 저장**

  ### 🚌 대중교통 배치 처리 API
  - **`POST /api/distance/trans`**: 여러 구간 동시 처리
  - **`TransDistanceBatchRequest`**: 배치 요청 DTO 추가
  - **전체 구간 성공 시에만 TripSegment 저장**

  ### 🔧 최적화
  - **탄소배출량 중복 계산 제거**: Section DTO에 carbonEmission 필드 추가
  - **API 응답 구조 단순화**: 최적 경로만 반환