### PR TITLE
feat: FCM 푸시 알림 기능 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,4 @@ out/
 /src/main/resources/application-secret.properties
 /src/main/resources/application-oauth.properties
 .env
+/src/main/resources/firebase/leafy-4f5c0-firebase-adminsdk-fbsvc-74b6a4ab9b.json

--- a/build.gradle
+++ b/build.gradle
@@ -53,6 +53,9 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-batch'
     implementation 'org.springframework.batch:spring-batch-core:5.2.2'
 
+    // fcm
+    implementation 'com.google.firebase:firebase-admin:9.5.0'
+
 
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'

--- a/src/main/java/com/chocobi/leafy/config/FirebaseConfig.java
+++ b/src/main/java/com/chocobi/leafy/config/FirebaseConfig.java
@@ -1,0 +1,35 @@
+package com.chocobi.leafy.config;
+
+import com.google.auth.oauth2.GoogleCredentials;
+import com.google.firebase.FirebaseApp;
+import com.google.firebase.FirebaseOptions;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.io.ClassPathResource;
+
+import javax.annotation.PostConstruct;
+import java.io.IOException;
+
+@Configuration
+@Slf4j
+public class FirebaseConfig {
+    @Value("${firebase.config.path}")
+    private String firebaseConfigPath;
+
+
+    @PostConstruct
+    public void init() throws IOException {
+        GoogleCredentials googleCredentials = GoogleCredentials
+                .fromStream(new ClassPathResource(firebaseConfigPath).getInputStream());
+
+        FirebaseOptions options = FirebaseOptions.builder()
+                .setCredentials(googleCredentials)
+                .build();
+
+        if (FirebaseApp.getApps().isEmpty()) {
+            FirebaseApp.initializeApp(options);
+            log.info("Firebase application has been initialized");
+        }
+    }
+}

--- a/src/main/java/com/chocobi/leafy/fcm/controller/FCMController.java
+++ b/src/main/java/com/chocobi/leafy/fcm/controller/FCMController.java
@@ -3,6 +3,7 @@ package com.chocobi.leafy.fcm.controller;
 import com.chocobi.leafy.fcm.service.FCMService;
 import com.chocobi.leafy.fcm.dto.FCMTokenDTO;
 import com.chocobi.leafy.fcm.service.UserDeviceService;
+import com.google.firebase.messaging.FirebaseMessagingException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
@@ -38,6 +39,15 @@ public class FCMController {
 
         log.info("사용자 ID {}로부터 FCM 토큰 삭제 요청 수신.", userId);
         userDeviceService.unregisterToken(userId, fcmTokenDTO.getFcmToken());
+
+        return ResponseEntity.ok().build();
+    }
+
+    // TEST
+    @PostMapping("/test-send")
+    public ResponseEntity<Void> testSend(@AuthenticationPrincipal Long userId,
+                                         @RequestBody FCMTokenDTO fcmTokenDTO) throws FirebaseMessagingException {
+        fcmService.sendNotificationToSingleDevice(fcmTokenDTO.getFcmToken(), "테스트 알림", "테스트 메시지입니다.");
 
         return ResponseEntity.ok().build();
     }

--- a/src/main/java/com/chocobi/leafy/fcm/controller/FCMController.java
+++ b/src/main/java/com/chocobi/leafy/fcm/controller/FCMController.java
@@ -47,8 +47,9 @@ public class FCMController {
     @PostMapping("/test-send")
     public ResponseEntity<Void> testSend(@AuthenticationPrincipal Long userId,
                                          @RequestBody FCMTokenDTO fcmTokenDTO) throws FirebaseMessagingException {
-        fcmService.sendNotificationToSingleDevice(fcmTokenDTO.getFcmToken(), "테스트 알림", "테스트 메시지입니다.");
+        fcmService.sendNotification(fcmTokenDTO.getFcmToken(), "테스트 알림", "테스트 메시지입니다.");
 
         return ResponseEntity.ok().build();
     }
+
 }

--- a/src/main/java/com/chocobi/leafy/fcm/controller/FCMController.java
+++ b/src/main/java/com/chocobi/leafy/fcm/controller/FCMController.java
@@ -1,0 +1,44 @@
+package com.chocobi.leafy.fcm.controller;
+
+import com.chocobi.leafy.fcm.service.FCMService;
+import com.chocobi.leafy.fcm.dto.FCMTokenDTO;
+import com.chocobi.leafy.fcm.service.UserDeviceService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+
+@Slf4j
+@RestController
+@RequestMapping("/api/fcm")
+@RequiredArgsConstructor
+public class FCMController {
+    private final FCMService fcmService;
+    private final UserDeviceService userDeviceService;
+
+    // 토큰 저장
+    @PostMapping("/register-token")
+    public ResponseEntity<Void> registerToken(
+            @AuthenticationPrincipal Long userId,
+            @RequestBody FCMTokenDTO fcmTokenDTO) {
+
+        log.info("사용자 ID {}로부터 FCM 토큰 등록 요청 수신.", userId);
+        userDeviceService.registerToken(userId, fcmTokenDTO.getFcmToken());
+
+        return ResponseEntity.ok().build();
+    }
+
+    // 토큰 삭제
+    @PostMapping("/unregister-token")
+    public ResponseEntity<Void> unregisterToken(
+            @AuthenticationPrincipal Long userId,
+            @RequestBody FCMTokenDTO fcmTokenDTO) {
+
+        log.info("사용자 ID {}로부터 FCM 토큰 삭제 요청 수신.", userId);
+        userDeviceService.unregisterToken(userId, fcmTokenDTO.getFcmToken());
+
+        return ResponseEntity.ok().build();
+    }
+}

--- a/src/main/java/com/chocobi/leafy/fcm/controller/UserDeviceController.java
+++ b/src/main/java/com/chocobi/leafy/fcm/controller/UserDeviceController.java
@@ -1,0 +1,36 @@
+package com.chocobi.leafy.fcm.controller;
+
+import com.chocobi.leafy.fcm.dto.FCMTokenDTO;
+import com.chocobi.leafy.fcm.service.UserDeviceService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/user")
+public class UserDeviceController {
+
+    private final UserDeviceService userDeviceService;
+
+    public UserDeviceController(UserDeviceService userDeviceService) {
+        this.userDeviceService = userDeviceService;
+    }
+
+    @PostMapping("/fcm-token")
+    public ResponseEntity<Void> registerToken(@RequestBody FCMTokenDTO request,
+                                              @AuthenticationPrincipal Long userId) { // 타입을 Long으로 변경
+        // 서비스 레이어에 FCM 토큰과 userId를 함께 전달
+        userDeviceService.registerToken(userId, request.getFcmToken());
+        return ResponseEntity.ok().build();
+    }
+
+    @PostMapping("/fcm-token-delete")
+    public ResponseEntity<Void> unregisterToken(@RequestBody FCMTokenDTO request,
+                                                @AuthenticationPrincipal Long userId) {
+        userDeviceService.unregisterToken(userId, request.getFcmToken());
+        return ResponseEntity.ok().build();
+    }
+}

--- a/src/main/java/com/chocobi/leafy/fcm/dto/FCMTokenDTO.java
+++ b/src/main/java/com/chocobi/leafy/fcm/dto/FCMTokenDTO.java
@@ -1,0 +1,8 @@
+package com.chocobi.leafy.fcm.dto;
+
+import lombok.Data;
+
+@Data
+public class FCMTokenDTO {
+    private String fcmToken;
+}

--- a/src/main/java/com/chocobi/leafy/fcm/entity/UserDevice.java
+++ b/src/main/java/com/chocobi/leafy/fcm/entity/UserDevice.java
@@ -1,0 +1,53 @@
+package com.chocobi.leafy.fcm.entity;
+
+import com.chocobi.leafy.user.entity.User;
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Entity
+@NoArgsConstructor
+@Getter
+public class UserDevice {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long Id;
+
+    @Column(name = "fcm_token", nullable = false, unique = true)
+    private String fcmToken;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @Column(name = "updated_at", nullable = false)
+    private LocalDateTime updatedAt;
+
+    public UserDevice(String fcmToken, User user) {
+        this.fcmToken = fcmToken;
+        this.user = user;
+        this.createdAt = LocalDateTime.now();
+        this.updatedAt = LocalDateTime.now();
+    }
+
+    @PrePersist
+    protected void onCreate() {
+        this.createdAt = LocalDateTime.now();
+        this.updatedAt = LocalDateTime.now();
+    }
+
+    @PreUpdate
+    protected void onUpdate() {
+        this.updatedAt = LocalDateTime.now();
+    }
+
+    public void updateUser(User user) {
+        this.user = user;
+        onUpdate(); // updatedAt도 갱신
+    }
+}

--- a/src/main/java/com/chocobi/leafy/fcm/repository/UserDeviceRepository.java
+++ b/src/main/java/com/chocobi/leafy/fcm/repository/UserDeviceRepository.java
@@ -1,0 +1,8 @@
+package com.chocobi.leafy.fcm.repository;
+
+import com.chocobi.leafy.fcm.entity.UserDevice;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UserDeviceRepository extends JpaRepository<UserDevice, Long> {
+
+}

--- a/src/main/java/com/chocobi/leafy/fcm/repository/UserDeviceRepository.java
+++ b/src/main/java/com/chocobi/leafy/fcm/repository/UserDeviceRepository.java
@@ -1,8 +1,12 @@
 package com.chocobi.leafy.fcm.repository;
 
 import com.chocobi.leafy.fcm.entity.UserDevice;
+import com.chocobi.leafy.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface UserDeviceRepository extends JpaRepository<UserDevice, Long> {
+import java.util.Optional;
 
+public interface UserDeviceRepository extends JpaRepository<UserDevice, Long> {
+    Optional<UserDevice> findByFcmToken(String fcmToken);
+    Optional<UserDevice> findByUserAndFcmToken(User user, String fcmToken);
 }

--- a/src/main/java/com/chocobi/leafy/fcm/service/FCMService.java
+++ b/src/main/java/com/chocobi/leafy/fcm/service/FCMService.java
@@ -5,12 +5,11 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
-
 @Slf4j
 @Service
 @RequiredArgsConstructor
 public class FCMService {
-    public void sendNotificationToSingleDevice(String fcmToken, String title, String body) throws FirebaseMessagingException {
+    public void sendNotification(String fcmToken, String title, String body) throws FirebaseMessagingException {
         Message message = Message.builder()
                 .setToken(fcmToken)
                 .setNotification(createNotification(title, body))
@@ -18,7 +17,6 @@ public class FCMService {
 
         FirebaseMessaging.getInstance().send(message);
     }
-
     private Notification createNotification(String title, String body) {
         return Notification.builder()
                 .setTitle(title)

--- a/src/main/java/com/chocobi/leafy/fcm/service/FCMService.java
+++ b/src/main/java/com/chocobi/leafy/fcm/service/FCMService.java
@@ -1,0 +1,28 @@
+package com.chocobi.leafy.fcm.service;
+
+import com.google.firebase.messaging.*;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class FCMService {
+    public void sendNotificationToSingleDevice(String fcmToken, String title, String body) throws FirebaseMessagingException {
+        Message message = Message.builder()
+                .setToken(fcmToken)
+                .setNotification(createNotification(title, body))
+                .build();
+
+        FirebaseMessaging.getInstance().send(message);
+    }
+
+    private Notification createNotification(String title, String body) {
+        return Notification.builder()
+                .setTitle(title)
+                .setBody(body)
+                .build();
+    }
+}

--- a/src/main/java/com/chocobi/leafy/fcm/service/UserDeviceService.java
+++ b/src/main/java/com/chocobi/leafy/fcm/service/UserDeviceService.java
@@ -1,0 +1,51 @@
+package com.chocobi.leafy.fcm.service;
+
+import com.chocobi.leafy.fcm.entity.UserDevice;
+import com.chocobi.leafy.fcm.repository.UserDeviceRepository;
+import com.chocobi.leafy.user.entity.User;
+import com.chocobi.leafy.user.service.UserService;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class UserDeviceService {
+    private final UserDeviceRepository userDeviceRepository;
+    private final UserService userService;
+
+    @Transactional
+    public void registerToken(Long userId, String fcmToken) {
+        // 1. 해당 사용자가 존재하는지 확인
+        User user = userService.findByKakaoId(userId);
+
+        // 2. 전달받은 토큰이 이미 DB에 등록되어 있는지 확인
+        userDeviceRepository.findByFcmToken(fcmToken)
+                .ifPresentOrElse(
+                        // 2-1. 토큰이 이미 존재하는 경우
+                        device -> {
+                            if (!device.getUser().getKakaoId().equals(user.getKakaoId())) {
+                                device.updateUser(user);
+                                log.info("FCM 토큰 {}의 사용자 정보가 ID {}로 업데이트되었습니다.", fcmToken, userId);
+                            } else {
+                                log.info("FCM 토큰 {}는 이미 ID {}에 등록되어 있습니다. 변경 없음.", fcmToken, userId);
+                            }
+                        },
+                        // 2-2. 토큰이 존재하지 않는 새로운 토큰인 경우
+                        () -> {
+                            UserDevice newDevice = new UserDevice(fcmToken, user);
+                            userDeviceRepository.save(newDevice);
+                            log.info("새로운 FCM 토큰이 사용자 ID {}에 성공적으로 등록되었습니다.", userId);
+                        }
+                );
+    }
+
+    @Transactional
+    public void unregisterToken(Long userId, String fcmToken) {
+        userDeviceRepository.findByUserAndFcmToken(userService.findByKakaoId(userId), fcmToken)
+                .ifPresent(userDeviceRepository::delete);
+        log.info("사용자 ID {}의 FCM 토큰 {}이 성공적으로 삭제되었습니다.", userId, fcmToken);
+    }
+}


### PR DESCRIPTION
### 🎯 Summary

FCM(Firebase Cloud Messaging)을 활용하여 푸시 알림 기능을 구현했습니다. 


### 🚀 Changes

FCMService 구현: sendNotification(): 특정 디바이스에 알림을 보내는 메서드를 추가했습니다.

FCM 토큰 관리: UserDevice 엔티티를 활용해 사용자와 디바이스를 1:N 관계로 연결하여 여러 기기에서 로그인해도 알림을 모두 받을 수 있도록 했습니다.


### 🖼️ API 엔드포인트:

POST /api/fcm/register-token: 클라이언트가 발급받은 FCM 토큰을 백엔드에 등록합니다.

POST /api/fcm/unregister-token: 클라이언트가 로그아웃 시 토큰을 삭제합니다.

테스트용 알림 기능: POST /api/fcm/test-send 엔드포인트를 통해 백엔드에서 테스트 알림을 쉽게 보낼 수 있도록 했습니다.


### 🔍 검증 방법

FCM 토큰 등록: 클라이언트에서 POST /api/fcm/register-token을 호출하여 UserDevice 테이블에 토큰이 정상적으로 저장되는지 확인합니다.

알림 전송: POST /api/fcm/test-send를 호출하여 알림이 정상적으로 오는지 확인합니다.

로그아웃: 클라이언트에서 로그아웃 시 토큰이 정상적으로 삭제되는지 확인합니다.