### PR TITLE
chore: 로컬 모니터링을 위한 Prometheus, Grafana 설정 추가

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,0 +1,5 @@
+{
+  "disabledMcpjsonServers": [
+    "notion-dev-log"
+  ]
+}

--- a/build.gradle
+++ b/build.gradle
@@ -52,6 +52,9 @@ dependencies {
 
     implementation 'com.google.firebase:firebase-admin:9.5.0'
 
+    implementation 'org.springframework.boot:spring-boot-starter-actuator'
+    implementation 'io.micrometer:micrometer-registry-prometheus'
+
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'
 

--- a/docker-compose.local.yml
+++ b/docker-compose.local.yml
@@ -1,0 +1,30 @@
+version: '3.8'
+
+services:  # 실행할 컨테이너 목록 (prometheus, grafana)
+  prometheus:  # prometheus 서비스
+    image: prom/prometheus:latest  # Docker Hub 공식 Prometheus 이미지 사용 (최신 버전)
+    container_name: prometheus  # 컨테이너 이름
+    ports:  # 호스트 : 컨테이너 형식. 로컬9090 -> 컨테이너9090으로 연결. localhost:9090으로 접근 가능해짐
+      - "9090:9090"
+    volumes:
+      - ./prometheus.yml:/etc/prometheus/prometheus.yml  # prometheus.yml을 컨테이너 내부 설정 파일 경로에 마운트. 내가 수정하면 컨테이너도 반영됨
+      - prometheus-data:/prometheus  # named volume으로 수집된 메트릭 데이터를 Docker가 관리하는 공간에 저장
+    command:  # Prometheus 실행 옵션
+      - '--config.file=/etc/prometheus/prometheus.yml'  # 설정 파일 경로 지정
+      - '--storage.tsdb.retention.time=3d'  # 메트릭 데이터 3일치만 보관
+    restart: unless-stopped  # 컨테이너 멈추면 자동 재시작. docker stop으로 직접 멈춘 경우엔 재시작 x
+
+  grafana:  # grafana 서비스
+    image: grafana/grafana:latest  # Docker Hub 공식 grafana 이미지 사용 (최신 버전)
+    container_name: grafana  # 컨테이너 이름
+    ports:  # 호스트 : 컨테이너 형식.
+      - "3000:3000"
+    volumes:  # Grafana 설정 데이터 저장. 컨테이너 재시작해도 설정 유지됨.
+      - grafana-data:/var/lib/grafana
+    depends_on:  # Prometheus 컨테이너가 먼저 시작된 후 Grafana 시작.
+      - prometheus
+    restart: unless-stopped
+
+volumes:  # named volume 선언부. 여기 명시해야 Docker가 볼륨을 생성하고 관리함.
+  prometheus-data:
+  grafana-data:

--- a/prometheus.yml
+++ b/prometheus.yml
@@ -1,0 +1,13 @@
+global:
+  scrape_interval: 60s
+  evaluation_interval: 60s
+
+scrape_configs:
+  - job_name: 'local'
+    metrics_path: '/actuator/prometheus'
+    scrape_interval: 10s
+    static_configs:
+      - targets: ['host.docker.internal:8080']
+        labels:
+          application: 'leafy'
+          namespace: 'default'

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -26,3 +26,14 @@ spring:
       enabled: true
     jdbc:
       initialize-schema: always
+
+management:
+  endpoints:
+    web:
+      exposure:
+        include: "prometheus"
+
+  prometheus:
+    metrics:
+      export:
+        enabled: true


### PR DESCRIPTION
## 🚨 관련 이슈


## 🚀 작업 목적
- 로컬 모니터링을 위한 Prometheus, Grafana 설정 추가

## 📝 작업 내용 
- Spring Actuator, micrometer 의존성 추가
- docker를 이용해 Prometheus, Grafana 컨테이너를 사용

사용 방법
`docker compose -f docker-compose.local.yml up -d`
`docker compose -f docker-compose.local.yml down`

## 🖼️ 스크린샷 (선택 사항)

## ✅ 체크리스트
- [ ] 코드 컨벤션을 준수했나요?
- [ ] 불필요한 주석이나 로그를 제거했나요?
- [ ] 테스트를 통과했나요?
- [ ] 변경 사항에 대한 문서를 업데이트했나요?