### PR TITLE
refactor: User 엔티티 PK를 kakaoId에서 자동생성 id로 변경

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,5 +1,0 @@
-{
-  "disabledMcpjsonServers": [
-    "notion-dev-log"
-  ]
-}

--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,0 +1,5 @@
+{
+  "disabledMcpjsonServers": [
+    "notion-dev-log"
+  ]
+}

--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,5 @@ out/
 /src/main/resources/application-oauth.yml
 .env
 /src/main/resources/firebase/
+
+.claude

--- a/src/main/java/com/chocobi/leafy/LeafyApplication.java
+++ b/src/main/java/com/chocobi/leafy/LeafyApplication.java
@@ -2,8 +2,10 @@ package com.chocobi.leafy;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @SpringBootApplication
+@EnableJpaAuditing
 public class LeafyApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/com/chocobi/leafy/fcm/service/FCMService.java
+++ b/src/main/java/com/chocobi/leafy/fcm/service/FCMService.java
@@ -27,7 +27,7 @@ public class FCMService {
         // 1. 사용자 디바이스 토큰 가져오기 (단일)
         Optional<UserDevice> deviceOpt = userDeviceRepository.findByUser(user);
         if (deviceOpt.isEmpty()) {
-            log.warn("❌ 사용자 {} 에 등록된 FCM 토큰이 없습니다.", user.getKakaoId());
+            log.warn("❌ 사용자 {} 에 등록된 FCM 토큰이 없습니다.", user.getId());  // TODO: 로직 동작 확인
             return;
         }
 
@@ -50,9 +50,9 @@ public class FCMService {
         // 3. 발송
         try {
             String response = FirebaseMessaging.getInstance().send(message);
-            log.info("✅ FCM 알림 전송 완료 - user={}, token={}, response={}", user.getKakaoId(), fcmToken, response);
+            log.info("✅ FCM 알림 전송 완료 - user={}, token={}, response={}", user.getId(), fcmToken, response);  // TODO: 로직 동작 확인
         } catch (FirebaseMessagingException e) {
-            log.error("❌ FCM 전송 실패 - user={}, token={}, reason={}", user.getKakaoId(), fcmToken, e.getMessagingErrorCode(), e);
+            log.error("❌ FCM 전송 실패 - user={}, token={}, reason={}", user.getId(), fcmToken, e.getMessagingErrorCode(), e);  // TODO: 로직 동작 확인
             // 실패 토큰 삭제
             userDeviceRepository.findByFcmToken(fcmToken)
                     .ifPresent(userDeviceRepository::delete);

--- a/src/main/java/com/chocobi/leafy/fcm/service/UserDeviceService.java
+++ b/src/main/java/com/chocobi/leafy/fcm/service/UserDeviceService.java
@@ -19,14 +19,14 @@ public class UserDeviceService {
     @Transactional
     public void registerToken(Long userId, String fcmToken) {
         // 1. 해당 사용자가 존재하는지 확인
-        User user = userService.findByKakaoId(userId);
+        User user = userService.findById(userId); // TODO: 로직 동작 확인
 
         // 2. 전달받은 토큰이 이미 DB에 등록되어 있는지 확인
         userDeviceRepository.findByFcmToken(fcmToken)
                 .ifPresentOrElse(
                         // 2-1. 토큰이 이미 존재하는 경우
                         device -> {
-                            if (!device.getUser().getKakaoId().equals(user.getKakaoId())) {
+                            if (!device.getUser().getId().equals(user.getId())) { // TODO: 로직 동작 확인
                                 device.updateUser(user);
                                 log.info("FCM 토큰 {}의 사용자 정보가 ID {}로 업데이트되었습니다.", fcmToken, userId);
                             } else {
@@ -44,7 +44,7 @@ public class UserDeviceService {
 
     @Transactional
     public void unregisterToken(Long userId, String fcmToken) {
-        userDeviceRepository.findByUserAndFcmToken(userService.findByKakaoId(userId), fcmToken)
+        userDeviceRepository.findByUserAndFcmToken(userService.findById(userId), fcmToken)  // TODO: 로직 동작 확인
                 .ifPresent(userDeviceRepository::delete);
         log.info("사용자 ID {}의 FCM 토큰 {}이 성공적으로 삭제되었습니다.", userId, fcmToken);
     }

--- a/src/main/java/com/chocobi/leafy/global/entity/BaseEntity.java
+++ b/src/main/java/com/chocobi/leafy/global/entity/BaseEntity.java
@@ -1,0 +1,16 @@
+package com.chocobi.leafy.global.entity;
+
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+
+@Getter
+@MappedSuperclass
+public abstract class BaseEntity extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+}

--- a/src/main/java/com/chocobi/leafy/global/entity/BaseTimeEntity.java
+++ b/src/main/java/com/chocobi/leafy/global/entity/BaseTimeEntity.java
@@ -1,0 +1,24 @@
+package com.chocobi.leafy.global.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@Getter
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public abstract class BaseTimeEntity {
+    @CreatedDate
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    @Column(name = "updated_at", nullable = false)
+    private LocalDateTime updatedAt;
+}

--- a/src/main/java/com/chocobi/leafy/post/dto/PostResponse.java
+++ b/src/main/java/com/chocobi/leafy/post/dto/PostResponse.java
@@ -42,7 +42,7 @@ public class PostResponse {
         UserInfo userInfo = null;
         if (post.getUser() != null) {
             userInfo = new UserInfo(
-                    post.getUser().getKakaoId(),
+                    post.getUser().getId(),  // TODO: 로직 동작 확인
                     post.getUser().getNickname(),
                     post.getUser().getProfileImageUrl()
             );

--- a/src/main/java/com/chocobi/leafy/post/service/PostService.java
+++ b/src/main/java/com/chocobi/leafy/post/service/PostService.java
@@ -29,7 +29,7 @@ public class PostService {
         Post post = Post.builder()
                 .title(request.getTitle())
                 .content(request.getContent())
-                .user(userService.findByKakaoId(request.getUserId()))
+                .user(userService.findById(request.getUserId()))  // TODO: 로직 동작 확인
                 .place(placeService.getPlaceById(request.getPlaceId()))
                 .rating(request.getRating())
                 .likes(0)
@@ -65,7 +65,7 @@ public class PostService {
     }
 
     public List<PostResponse> getPostByUser(Long userId) {
-        return postRepository.findByUser(userService.findByKakaoId(userId)).stream()
+        return postRepository.findByUser(userService.findById(userId)).stream()  // TODO: 로직 동작 확인
                 .map(PostResponse::fromEntity)
                 .toList();
     }
@@ -79,7 +79,7 @@ public class PostService {
     @Transactional
     public PostResponse toggleLike(Long postId, Long userId) {
         Post post = getPostById(postId);
-        User user = userService.findByKakaoId(userId);
+        User user = userService.findById(userId);  // TODO: 로직 동작 확인
 
         boolean isCurrentlyLiked = userPostLikeRepository.existsByUserAndPost(user, post);
 
@@ -102,7 +102,7 @@ public class PostService {
     }
 
     public List<Long> getUserLikedPostIds(Long userId) {
-        User user = userService.findByKakaoId(userId);
+        User user = userService.findById(userId);  // TODO: 로직 동작 확인
         return userPostLikeRepository.findPostIdsByUser(user);
     }
 }

--- a/src/main/java/com/chocobi/leafy/trip/dto/TripDTO.java
+++ b/src/main/java/com/chocobi/leafy/trip/dto/TripDTO.java
@@ -40,7 +40,7 @@ public class TripDTO {
                 trip.getCarbonEmission(),
                 trip.getStatus(),
                 trip.getCertificationAt(),
-                trip.getUser().getKakaoId(),
+                trip.getUser().getId(),  // TODO: 로직 동작 확인
                 trip.getTripPlaces().stream()
                         .map(TripPlaceResponse::toDTO)
                         .sorted(Comparator.comparingInt(TripPlaceResponse::getVisitOrder))

--- a/src/main/java/com/chocobi/leafy/trip/repository/TripRepository.java
+++ b/src/main/java/com/chocobi/leafy/trip/repository/TripRepository.java
@@ -13,7 +13,7 @@ import java.util.List;
 @Repository
 public interface TripRepository extends JpaRepository<Trip, Long> {
     List<Trip> findByStatusAndCreatedAtBefore(TripStatus status, LocalDateTime createdAt);
-    List<Trip> findByUserKakaoIdOrderByCreatedAtDesc(Long kakaoId);
+    List<Trip> findByUserIdOrderByCreatedAtDesc(Long id);  // TODO: 로직 동작 확인
     List<Trip> findAllByStartDateAndStatus(LocalDate startDate, TripStatus status);
     List<Trip> findAllByUser(User user);
 }

--- a/src/main/java/com/chocobi/leafy/trip/service/TripMessageService.java
+++ b/src/main/java/com/chocobi/leafy/trip/service/TripMessageService.java
@@ -24,7 +24,7 @@ public class TripMessageService {
      */
     @Transactional
     public void notifyTripCreated(Long userId, Long tripId) throws FirebaseMessagingException {
-        User user = userService.findByKakaoId(userId);
+        User user = userService.findById(userId);  // TODO: 로직 동작 확인
         Trip trip = tripService.getTripById(tripId);
 
         Map<String, String> data = Map.of(

--- a/src/main/java/com/chocobi/leafy/trip/service/TripService.java
+++ b/src/main/java/com/chocobi/leafy/trip/service/TripService.java
@@ -30,7 +30,7 @@ public class TripService {
     @Transactional
     public Long createTrip(TripRequest tripRequest, Long kakaoId) {
         Trip trip = Trip.builder()
-                .user(userService.findByKakaoId(kakaoId))
+                .user(userService.findById(kakaoId))  // TODO: 로직 동작 확인
                 .title(tripRequest.getTitle())
                 .startDate(tripRequest.getStart_date())
                 .endDate(tripRequest.getEnd_date())

--- a/src/main/java/com/chocobi/leafy/user/controller/UserController.java
+++ b/src/main/java/com/chocobi/leafy/user/controller/UserController.java
@@ -1,6 +1,6 @@
 package com.chocobi.leafy.user.controller;
 
-import com.chocobi.leafy.user.entity.Level;
+import com.chocobi.leafy.user.enums.Level;
 import com.chocobi.leafy.user.entity.User;
 import com.chocobi.leafy.user.dto.LevelIconUpdateDto;
 import com.chocobi.leafy.user.dto.NicknameUpdateDto;
@@ -48,7 +48,7 @@ public class UserController {
         Long kakaoId = Long.parseLong(authentication.getName());
 
         // 기존 사용자 정보 조회
-        User user = userService.findByKakaoId(kakaoId);
+        User user = userService.findById(kakaoId);  // TODO: 로직 동작 확인
 
         // 닉네임 수정
         user.updateNickname(nicknameUpdateDto.getNickname());
@@ -69,7 +69,7 @@ public class UserController {
     @PutMapping("/test/level")
     public ResponseEntity<String> updateTestLevel(@RequestBody Map<String, String> request, Authentication authentication) {
         Long kakaoId = Long.parseLong(authentication.getName());
-        User user = userService.findByKakaoId(kakaoId);
+        User user = userService.findById(kakaoId);  // TODO: 로직 동작 확인
 
         try {
             Level newLevel = Level.valueOf(request.get("level"));
@@ -86,7 +86,7 @@ public class UserController {
     @PutMapping("/test/carbon")
     public ResponseEntity<String> updateTestCarbon(@RequestBody Map<String, Double> request, Authentication authentication) {
         Long kakaoId = Long.parseLong(authentication.getName());
-        User user = userService.findByKakaoId(kakaoId);
+        User user = userService.findById(kakaoId);  // TODO: 로직 동작 확인
 
         try {
             Double carbonAmount = request.get("totalCarbonSaved");

--- a/src/main/java/com/chocobi/leafy/user/dto/UserProfileDto.java
+++ b/src/main/java/com/chocobi/leafy/user/dto/UserProfileDto.java
@@ -6,7 +6,7 @@ import lombok.Getter;
 @Getter
 @Builder
 public class UserProfileDto {
-    private Long kakaoId;
+    private String kakaoId;  // TODO: 로직 동작 확인
     private String nickname;
     private String profileImageUrl;
     private String role;

--- a/src/main/java/com/chocobi/leafy/user/entity/User.java
+++ b/src/main/java/com/chocobi/leafy/user/entity/User.java
@@ -1,89 +1,65 @@
 package com.chocobi.leafy.user.entity;
 
+import com.chocobi.leafy.global.entity.BaseEntity;
+import com.chocobi.leafy.user.enums.Level;
+import com.chocobi.leafy.user.enums.Provider;
+import com.chocobi.leafy.user.enums.Role;
 import jakarta.persistence.*;
 import lombok.*;
 
-import java.time.LocalDateTime;
-
-import static com.chocobi.leafy.constants.Kakao.CarbonInit;
 import static com.chocobi.leafy.user.util.LevelCalculator.calculateLevel;
 
-@Entity // db 테이블 생성
-@Table(name = "users") // 테이블명 설정. user는 예약어라 사용 불가
-@Getter // lombook을 통해 컴파일 시 getter 자동 설정
-@NoArgsConstructor(access = AccessLevel.PROTECTED) // 기본 생성자를 만들어줌. 외부에서는 접근하지 못하게 제한
-public class User {
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Table(name = "users")
+public class User extends BaseEntity {
 
-    @Id
-    @Column(name = "kakao_id", nullable = false, unique = true) // DB column 설정
-    private Long kakaoId;
-
-    @Column(nullable = false, length = 12)
+    @Column(name = "nickname", nullable = false, length = 12)
     private String nickname;
 
-    @Column(name = "profile_image_url")
+    @Column(name = "profile_image_url", nullable = false)
     private String profileImageUrl;
 
     @Enumerated(EnumType.STRING)
     @Column(name = "role", nullable = false)
-    private Role role;
+    @Builder.Default
+    private Role role = Role.USER;
 
-    @Enumerated(EnumType.STRING) // enum을 문자열로 저장
-    @Column(nullable = false) // default 값이 Lv1인 것 저장
-    private Level level;
+    @Setter
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    @Builder.Default
+    private Level level = Level.LV1;
 
-    @Column(name = "total_carbon_saved")
-    private double totalCarbonSaved;
+    @Column(name = "total_carbon_saved", nullable = false)
+    @Builder.Default
+    private double totalCarbonSaved = 0.0;
 
-    @Column
-    private Level selectedLevelIcon;
+    @Column(name = "selected_level_icon", nullable = false)
+    @Enumerated(EnumType.STRING)
+    @Builder.Default
+    private Level selectedLevelIcon = Level.LV1;
 
-    @Column(name = "created_at")
-    private LocalDateTime createdAt;
+    @Column(name = "provider", nullable = false)
+    private Provider provider;
 
-    @Column(name = "updated_at")
-    private LocalDateTime updatedAt;
-
-    @Builder
-    public User(Long kakaoId, String nickname, String profileImageUrl) {
-        this.kakaoId = kakaoId;
-        this.nickname = nickname;
-        this.profileImageUrl = profileImageUrl;
-        this.role = Role.USER;
-        this.level = Level.LV1; // 초기 레벨은 무조건 1
-        this.totalCarbonSaved = CarbonInit; // 초기 탄소 절감량 0
-        this.selectedLevelIcon = Level.LV1;
-    }
-
-    /**
-     * data insert 직전에 실행되는 어노테이션
-     */
-    @PrePersist
-    public void creatTime() {
-        this.createdAt = LocalDateTime.now();
-        this.updatedAt = LocalDateTime.now();
-    }
+    @Column(name = "provider_id", nullable = false)
+    private String providerId;
 
     public void updateNickname(String nickname) {
         this.nickname = nickname;
-        this.updatedAt = LocalDateTime.now();
     }
 
     public void updateSelectedLevelIcon(Level level) {
         this.selectedLevelIcon = level;
-        this.updatedAt = LocalDateTime.now();
-    }
-
-    // 테스트용 레벨 설정 메서드
-    public void setLevel(Level level) {
-        this.level = level;
-        this.updatedAt = LocalDateTime.now();
     }
 
     // 테스트용 탄소 절감량 설정 메서드
     public void setTotalCarbonSaved(double totalCarbonSaved) {
         this.totalCarbonSaved = totalCarbonSaved;
         this.level = calculateLevel(totalCarbonSaved); // 레벨 자동 계산
-        this.updatedAt = LocalDateTime.now();
     }
 }

--- a/src/main/java/com/chocobi/leafy/user/enums/Level.java
+++ b/src/main/java/com/chocobi/leafy/user/enums/Level.java
@@ -1,4 +1,4 @@
-package com.chocobi.leafy.user.entity;
+package com.chocobi.leafy.user.enums;
 
 public enum Level {
     LV1, LV2, LV3, LV4, LV5;

--- a/src/main/java/com/chocobi/leafy/user/enums/Provider.java
+++ b/src/main/java/com/chocobi/leafy/user/enums/Provider.java
@@ -1,0 +1,5 @@
+package com.chocobi.leafy.user.enums;
+
+public enum Provider {
+    KAKAO, NAVER;
+}

--- a/src/main/java/com/chocobi/leafy/user/enums/Role.java
+++ b/src/main/java/com/chocobi/leafy/user/enums/Role.java
@@ -1,4 +1,4 @@
-package com.chocobi.leafy.user.entity;
+package com.chocobi.leafy.user.enums;
 
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;

--- a/src/main/java/com/chocobi/leafy/user/repository/UserRepository.java
+++ b/src/main/java/com/chocobi/leafy/user/repository/UserRepository.java
@@ -11,10 +11,11 @@ import java.util.Optional;
 
 @Repository
 public interface UserRepository extends JpaRepository<User, Long> {
-    Optional<User> findByKakaoId(Long kakaoId); // 유저가 있을 수도 있고, 없을 수도 있음
 
     @Modifying
     @Transactional
-    @Query("update User u set u.totalCarbonSaved = u.totalCarbonSaved + ?2 where u.kakaoId = ?1")
-    void updateCarbonSaved(Long kakaoId, double carbonSaved);
+    @Query("update User u set u.totalCarbonSaved = u.totalCarbonSaved + ?2 where u.id = ?1")  // TODO: 로직 동작 확인
+    void updateCarbonSaved(Long id, double carbonSaved);
+
+    Optional<User> findByProviderId(String providerId);  // TODO: 로직 동작 확인
 }

--- a/src/main/java/com/chocobi/leafy/user/service/OAuth2UserService.java
+++ b/src/main/java/com/chocobi/leafy/user/service/OAuth2UserService.java
@@ -34,7 +34,7 @@ public class OAuth2UserService extends DefaultOAuth2UserService {
                 .getUserNameAttributeName();
 
         Map<String, Object> attributes = oAuth2User.getAttributes();
-        Long kakaoId = ((Number) attributes.get("id")).longValue();
+        String kakaoId = attributes.get("id").toString();  // TODO: 로직 동작 확인
         Map<String, Object> kakaoAccount = (Map<String, Object>) attributes.get("kakao_account");
         Map<String, Object> profile = (Map<String, Object>) kakaoAccount.get("profile");
 

--- a/src/main/java/com/chocobi/leafy/user/service/UserService.java
+++ b/src/main/java/com/chocobi/leafy/user/service/UserService.java
@@ -3,7 +3,7 @@ package com.chocobi.leafy.user.service;
 import com.chocobi.leafy.trip.entity.Trip;
 import com.chocobi.leafy.trip.repository.TripRepository;
 import com.chocobi.leafy.user.dto.UserTripDto;
-import com.chocobi.leafy.user.entity.Level;
+import com.chocobi.leafy.user.enums.Level;
 import com.chocobi.leafy.user.entity.User;
 import com.chocobi.leafy.user.dto.UserProfileDto;
 import com.chocobi.leafy.user.repository.UserRepository;
@@ -28,11 +28,11 @@ public class UserService {
      * @param profileImageUrl
      * @return
      */
-    public User saveOrGetUser(Long kakaoId, String nickname, String profileImageUrl) {
-        return userRepository.findByKakaoId(kakaoId)
+    public User saveOrGetUser(String kakaoId, String nickname, String profileImageUrl) {
+        return userRepository.findByProviderId((kakaoId))  // TODO: 로직 동작 확인
                 .orElseGet(() -> { // Optional<User>이 비어있으면, 안에 있는 함수를 실행해서 값을 새로 만들어 리턴함
                     User newUser = User.builder()
-                            .kakaoId(kakaoId)
+                            .providerId(kakaoId)  // TODO: 로직 동작 확인
                             .nickname(nickname)
                             .profileImageUrl(profileImageUrl)
                             .build();
@@ -49,19 +49,20 @@ public class UserService {
         userRepository.updateCarbonSaved(kakaoId, carbonSaved);
     }
 
-    public User findByKakaoId(Long kakaoId) {
-        return userRepository.findByKakaoId(kakaoId)
+    // TODO: 로직 동작 확인
+    public User findById(Long id) {
+        return userRepository.findById(id)
                 .orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다."));
     }
 
     @Transactional(readOnly = true) // 읽기 전용
-    public UserProfileDto getUserProfile(Long kakaoId) {
-        User user = userRepository.findByKakaoId(kakaoId)
-                .orElseThrow(() -> new IllegalArgumentException("User not found with kakaoId: " + kakaoId));
+    public UserProfileDto getUserProfile(Long id) {
+        User user = userRepository.findById(id)  // TODO: 로직 동작 확인
+                .orElseThrow(() -> new IllegalArgumentException("User not found with id: " + id));
 
         // User 엔티티를 UserProfileDto로 변환
         return UserProfileDto.builder()
-                .kakaoId(user.getKakaoId())
+                .kakaoId(user.getProviderId())  // TODO: 로직 동작 확인
                 .nickname(user.getNickname())
                 .profileImageUrl(user.getProfileImageUrl())
                 .role(user.getRole().name())
@@ -73,9 +74,9 @@ public class UserService {
     }
 
     @Transactional
-    public void updateSelectedLevelIcon(Long kakaoId, String selectedLevelIcon) {
+    public void updateSelectedLevelIcon(Long id, String selectedLevelIcon) {
 
-        User user = findByKakaoId(kakaoId);
+        User user = findById(id);  // TODO: 로직 동작 확인
 
         Level iconLevel;
         try {
@@ -99,8 +100,8 @@ public class UserService {
     }
 
     @Transactional(readOnly = true)
-    public List<UserTripDto> getUserTrips(Long kakaoId) {
-        List<Trip> trips = tripRepository.findByUserKakaoIdOrderByCreatedAtDesc(kakaoId);
+    public List<UserTripDto> getUserTrips(Long id) {
+        List<Trip> trips = tripRepository.findByUserIdOrderByCreatedAtDesc(id);  // TODO: 로직 동작 확인
         
         return trips.stream()
                 .map(trip -> UserTripDto.builder()

--- a/src/main/java/com/chocobi/leafy/user/util/LevelCalculator.java
+++ b/src/main/java/com/chocobi/leafy/user/util/LevelCalculator.java
@@ -1,6 +1,6 @@
 package com.chocobi.leafy.user.util;
 
-import com.chocobi.leafy.user.entity.Level;
+import com.chocobi.leafy.user.enums.Level;
 
 public class LevelCalculator {
 


### PR DESCRIPTION
## 🚨 관련 이슈
#75 

## 🚀 작업 목적
- 여러 공급자를 추가하기 위한 User 엔티티 리팩토링

## 📝 작업 내용 
- User 엔티티의 PK를 kakaoId에서 자동생성 id로 변경
- 기존 코드를 오류가 나지 않도록 수정
- 비즈니스 로직은 검증하지 않고 수정함
  - 추후 비즈니스 로직 검증 필요
  - `TODO: 로직 작동 확인`으로 검증 필요한 부분 주석 추가

## 🖼️ 스크린샷 (선택 사항)

## ✅ 체크리스트
- [ ] 코드 컨벤션을 준수했나요?
- [ ] 불필요한 주석이나 로그를 제거했나요?
- [ ] 테스트를 통과했나요?
- [ ] 변경 사항에 대한 문서를 업데이트했나요?