### PR TITLE
feat: 공통 응답 및 예외처리 추가

### DIFF
--- a/src/main/java/com/chocobi/leafy/global/exception/CustomException.java
+++ b/src/main/java/com/chocobi/leafy/global/exception/CustomException.java
@@ -1,0 +1,13 @@
+package com.chocobi.leafy.global.exception;
+
+import lombok.Getter;
+
+@Getter
+public class CustomException extends RuntimeException {
+    private final ErrorCode errorCode;
+
+    public CustomException(ErrorCode errorCode) {
+        super(errorCode.getMessage());
+        this.errorCode = errorCode;
+    }
+}

--- a/src/main/java/com/chocobi/leafy/global/exception/ErrorCode.java
+++ b/src/main/java/com/chocobi/leafy/global/exception/ErrorCode.java
@@ -1,0 +1,18 @@
+package com.chocobi.leafy.global.exception;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum ErrorCode {
+    INVALID_INPUT_VALUE(HttpStatus.BAD_REQUEST, "잘못된 입력값입니다."),
+    ENTITY_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 리소스입니다."),
+    UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "인증이 필요합니다."),
+    FORBIDDEN(HttpStatus.FORBIDDEN, "접근 권한이 없습니다."),
+    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버 오류가 발생했습니다.");
+
+    private final HttpStatus status;
+    private final String message;
+}

--- a/src/main/java/com/chocobi/leafy/global/exception/ErrorResponse.java
+++ b/src/main/java/com/chocobi/leafy/global/exception/ErrorResponse.java
@@ -1,0 +1,24 @@
+package com.chocobi.leafy.global.exception;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+public class ErrorResponse {
+    private final int status;
+    private final String code;
+    private final String message;
+    private final LocalDateTime timestamp;
+
+    public static ErrorResponse of(ErrorCode errorCode) {
+        return ErrorResponse.builder()
+                .status(errorCode.getStatus().value())
+                .code(errorCode.name())
+                .message(errorCode.getMessage())
+                .timestamp(LocalDateTime.now())
+                .build();
+    }
+}

--- a/src/main/java/com/chocobi/leafy/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/chocobi/leafy/global/exception/GlobalExceptionHandler.java
@@ -1,0 +1,49 @@
+package com.chocobi.leafy.global.exception;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.BindingResult;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@Slf4j
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(CustomException.class)
+    public ResponseEntity<ErrorResponse> handleCustomException(CustomException e) {
+        log.error("커스텀 예외 발생: {}", e.getMessage());
+        ErrorCode errorCode = e.getErrorCode();
+        return ResponseEntity
+                .status(errorCode.getStatus())
+                .body(ErrorResponse.of(errorCode));
+    }
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<ErrorResponse> handleValidationException(MethodArgumentNotValidException e) {
+        BindingResult bindingResult = e.getBindingResult();
+        String message = bindingResult.getFieldErrors().stream()
+                .map(error -> error.getField() + ": " + error.getDefaultMessage())
+                .findFirst()
+                .orElse(ErrorCode.INVALID_INPUT_VALUE.getMessage());
+
+        log.error("입력값 유효성 검사 실패: {}", message);
+        return ResponseEntity
+                .status(ErrorCode.INVALID_INPUT_VALUE.getStatus())
+                .body(ErrorResponse.builder()
+                        .status(ErrorCode.INVALID_INPUT_VALUE.getStatus().value())
+                        .code(ErrorCode.INVALID_INPUT_VALUE.name())
+                        .message(message)
+                        .timestamp(java.time.LocalDateTime.now())
+                        .build());
+    }
+
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<ErrorResponse> handleException(Exception e) {
+        log.error("서버 내부 오류 발생: {}", e.getMessage());
+        return ResponseEntity
+                .status(ErrorCode.INTERNAL_SERVER_ERROR.getStatus())
+                .body(ErrorResponse.of(ErrorCode.INTERNAL_SERVER_ERROR));
+    }
+}

--- a/src/main/java/com/chocobi/leafy/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/chocobi/leafy/global/exception/GlobalExceptionHandler.java
@@ -1,5 +1,6 @@
 package com.chocobi.leafy.global.exception;
 
+import java.time.LocalDateTime;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.BindingResult;
@@ -35,13 +36,13 @@ public class GlobalExceptionHandler {
                         .status(ErrorCode.INVALID_INPUT_VALUE.getStatus().value())
                         .code(ErrorCode.INVALID_INPUT_VALUE.name())
                         .message(message)
-                        .timestamp(java.time.LocalDateTime.now())
+                        .timestamp(LocalDateTime.now())
                         .build());
     }
 
     @ExceptionHandler(Exception.class)
     public ResponseEntity<ErrorResponse> handleException(Exception e) {
-        log.error("서버 내부 오류 발생: {}", e.getMessage());
+        log.error("서버 내부 오류 발생: {}", e.getMessage(), e);
         return ResponseEntity
                 .status(ErrorCode.INTERNAL_SERVER_ERROR.getStatus())
                 .body(ErrorResponse.of(ErrorCode.INTERNAL_SERVER_ERROR));

--- a/src/main/java/com/chocobi/leafy/global/response/ApiResponse.java
+++ b/src/main/java/com/chocobi/leafy/global/response/ApiResponse.java
@@ -1,0 +1,20 @@
+package com.chocobi.leafy.global.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class ApiResponse<T> {
+    private final String code;
+    private final String message;
+    private final T data;
+
+    public static <T> ApiResponse<T> of(T data) {
+        return ApiResponse.<T>builder()
+                .code("SUCCESS")
+                .message("요청이 성공했습니다.")
+                .data(data)
+                .build();
+    }
+}

--- a/src/main/java/com/chocobi/leafy/global/response/PageResponse.java
+++ b/src/main/java/com/chocobi/leafy/global/response/PageResponse.java
@@ -9,11 +9,11 @@ import java.util.List;
 @Getter
 @Builder
 public class PageResponse<T> {
-    private List<T> content;
-    private int page;
-    private int size;
-    private Long totalElements;
-    private int totalPages;
+    private final List<T> content;
+    private final int page;
+    private final int size;
+    private final Long totalElements;
+    private final int totalPages;
 
     public static <T> PageResponse<T> of(Page<T> page) {
         return PageResponse.<T>builder()

--- a/src/main/java/com/chocobi/leafy/global/response/PageResponse.java
+++ b/src/main/java/com/chocobi/leafy/global/response/PageResponse.java
@@ -1,0 +1,27 @@
+package com.chocobi.leafy.global.response;
+
+import lombok.Builder;
+import lombok.Getter;
+import org.springframework.data.domain.Page;
+
+import java.util.List;
+
+@Getter
+@Builder
+public class PageResponse<T> {
+    private List<T> content;
+    private int page;
+    private int size;
+    private Long totalElements;
+    private int totalPages;
+
+    public static <T> PageResponse<T> of(Page<T> page) {
+        return PageResponse.<T>builder()
+                .content(page.getContent())
+                .page(page.getNumber())
+                .size(page.getSize())
+                .totalElements(page.getTotalElements())
+                .totalPages(page.getTotalPages())
+                .build();
+    }
+}


### PR DESCRIPTION
## 🚨 관련 이슈


## 🚀 작업 목적
-  예외 처리 및 공통 응답 구조를 표준화하여 일관된 API 응답 형식 제공

## 📝 작업 내용 
### 공통 응답
- `ApiResponse` : 성공 응답 래퍼 클래스 추가 (`code`, `message`, `data`)
- `PageResponse` : 페이지네이션 응답 래퍼 클래스 추가

### 예외 처리
- `ErrorCode` : 공통 에러 코드 enum 추가
- `ErrorResponse` : 에러 응답 클래스 추가 (`status`, `code`, `message`, `timestamp`)
- `CustomException` : 커스텀 예외 베이스 클래스 추가
- `GlobalExceptionHandler` : 전역 예외 핸들러 추가 (CustomException, Validation, Exception 처리)


## 🖼️ 스크린샷 (선택 사항)

## ✅ 체크리스트
- [ ] 코드 컨벤션을 준수했나요?
- [ ] 불필요한 주석이나 로그를 제거했나요?
- [ ] 테스트를 통과했나요?
- [ ] 변경 사항에 대한 문서를 업데이트했나요?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 전역 예외 처리 도입으로 오류가 일관된 HTTP 응답 형식으로 반환됩니다.
  * 표준화된 오류 코드와 메시지 집합을 추가했습니다.
  * 성공 응답과 페이징 응답을 위한 공통 응답 포맷을 제공하여 API 응답 일관성을 강화했습니다.

* **Refactor**
  * 응답·오류 처리 구조를 통합해 전역에서 일관된 메시지와 상태 관리를 구현했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->