### PR TITLE
refactor: 도메인별 에러 코드 구조로 분리

### DIFF
--- a/src/main/java/com/chocobi/leafy/global/exception/ErrorCode.java
+++ b/src/main/java/com/chocobi/leafy/global/exception/ErrorCode.java
@@ -1,18 +1,16 @@
 package com.chocobi.leafy.global.exception;
 
-import lombok.Getter;
-import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 
-@Getter
-@RequiredArgsConstructor
-public enum ErrorCode {
-    INVALID_INPUT_VALUE(HttpStatus.BAD_REQUEST, "잘못된 입력값입니다."),
-    ENTITY_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 리소스입니다."),
-    UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "인증이 필요합니다."),
-    FORBIDDEN(HttpStatus.FORBIDDEN, "접근 권한이 없습니다."),
-    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버 오류가 발생했습니다.");
+public interface ErrorCode {
+    HttpStatus getStatus();
+    String getMessage();
 
-    private final HttpStatus status;
-    private final String message;
+    default String getCode() {
+        if (this instanceof Enum<?> enumValue) {
+            return enumValue.name();
+        }
+
+        return getClass().getSimpleName();
+    }
 }

--- a/src/main/java/com/chocobi/leafy/global/exception/ErrorResponse.java
+++ b/src/main/java/com/chocobi/leafy/global/exception/ErrorResponse.java
@@ -16,7 +16,7 @@ public class ErrorResponse {
     public static ErrorResponse of(ErrorCode errorCode) {
         return ErrorResponse.builder()
                 .status(errorCode.getStatus().value())
-                .code(errorCode.name())
+                .code(errorCode.getCode())
                 .message(errorCode.getMessage())
                 .timestamp(LocalDateTime.now())
                 .build();

--- a/src/main/java/com/chocobi/leafy/global/exception/GlobalError.java
+++ b/src/main/java/com/chocobi/leafy/global/exception/GlobalError.java
@@ -1,0 +1,17 @@
+package com.chocobi.leafy.global.exception;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum GlobalError implements ErrorCode {
+    INVALID_INPUT_VALUE(HttpStatus.BAD_REQUEST, "잘못된 입력값입니다."),
+    UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "인증이 필요합니다."),
+    FORBIDDEN(HttpStatus.FORBIDDEN, "접근 권한이 없습니다."),
+    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버 오류가 발생했습니다.");
+
+    private final HttpStatus status;
+    private final String message;
+}

--- a/src/main/java/com/chocobi/leafy/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/chocobi/leafy/global/exception/GlobalExceptionHandler.java
@@ -27,14 +27,14 @@ public class GlobalExceptionHandler {
         String message = bindingResult.getFieldErrors().stream()
                 .map(error -> error.getField() + ": " + error.getDefaultMessage())
                 .findFirst()
-                .orElse(ErrorCode.INVALID_INPUT_VALUE.getMessage());
+                .orElse(GlobalError.INVALID_INPUT_VALUE.getMessage());
 
         log.error("입력값 유효성 검사 실패: {}", message);
         return ResponseEntity
-                .status(ErrorCode.INVALID_INPUT_VALUE.getStatus())
+                .status(GlobalError.INVALID_INPUT_VALUE.getStatus())
                 .body(ErrorResponse.builder()
-                        .status(ErrorCode.INVALID_INPUT_VALUE.getStatus().value())
-                        .code(ErrorCode.INVALID_INPUT_VALUE.name())
+                        .status(GlobalError.INVALID_INPUT_VALUE.getStatus().value())
+                        .code(GlobalError.INVALID_INPUT_VALUE.getCode())
                         .message(message)
                         .timestamp(LocalDateTime.now())
                         .build());
@@ -44,7 +44,7 @@ public class GlobalExceptionHandler {
     public ResponseEntity<ErrorResponse> handleException(Exception e) {
         log.error("서버 내부 오류 발생: {}", e.getMessage(), e);
         return ResponseEntity
-                .status(ErrorCode.INTERNAL_SERVER_ERROR.getStatus())
-                .body(ErrorResponse.of(ErrorCode.INTERNAL_SERVER_ERROR));
+                .status(GlobalError.INTERNAL_SERVER_ERROR.getStatus())
+                .body(ErrorResponse.of(GlobalError.INTERNAL_SERVER_ERROR));
     }
 }

--- a/src/main/java/com/chocobi/leafy/post/infra/PostFindService.java
+++ b/src/main/java/com/chocobi/leafy/post/infra/PostFindService.java
@@ -1,7 +1,7 @@
 package com.chocobi.leafy.post.infra;
 
 import com.chocobi.leafy.global.exception.CustomException;
-import com.chocobi.leafy.global.exception.ErrorCode;
+import com.chocobi.leafy.post.vo.PostError;
 import com.chocobi.leafy.post.dto.request.PostPageRequest;
 import com.chocobi.leafy.post.infra.entity.PostEntity;
 import com.chocobi.leafy.post.infra.repository.PostRepository;
@@ -22,7 +22,7 @@ public class PostFindService {
 
     public PostEntity findPost(Long id) {
         return postRepository.findById(id)
-                .orElseThrow(() -> new CustomException(ErrorCode.ENTITY_NOT_FOUND));
+                .orElseThrow(() -> new CustomException(PostError.POST_NOT_FOUND));
     }
 
     public List<PostEntity> findPosts() {

--- a/src/main/java/com/chocobi/leafy/post/vo/PostError.java
+++ b/src/main/java/com/chocobi/leafy/post/vo/PostError.java
@@ -1,0 +1,15 @@
+package com.chocobi.leafy.post.vo;
+
+import com.chocobi.leafy.global.exception.ErrorCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum PostError implements ErrorCode {
+    POST_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 게시글입니다.");
+
+    private final HttpStatus status;
+    private final String message;
+}

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -11,45 +11,47 @@ VALUES
 (1, 12345678, 'fcm_token_sample_123', NOW(), NOW()),
 (2, 87654321, 'fcm_token_sample_admin', NOW(), NOW());
 
--- 3. 장소 데이터 (Place)
-INSERT INTO place (id, latitude, longitude, url, address, title, category, region_group, source_type, description)
-VALUES
-(1, 37.55117, 126.9882, 'https://place.com/1', '서울 용산구 남산공원길 105', '남산서울타워', 'NATURE', 'SEOUL', 'API', '서울의 랜드마크입니다.'),
-(2, 35.1587, 129.1604, 'https://place.com/2', '부산 해운대구 해운대해변로 264', '해운대 해수욕장', 'NATURE', 'BUSAN', 'API', '여름철 최고의 휴양지입니다.'),
-(3, 37.5796, 126.9770, 'https://place.com/3', '서울 종로구 사직로 161', '경복궁', 'CULTURE', 'SEOUL', 'API', '조선 시대의 법궁입니다.'),
-(4, 33.4581, 126.9426, 'https://place.com/4', '제주 서귀포시 성산읍', '성산일출봉', 'NATURE', 'JEJU', 'API', '유네스코 세계자연유산입니다.');
+-- 3. 지역 데이터 먼저 삽입 (ID: 1, 2, 3...)
+INSERT INTO region (id, name, parent_id, level) VALUES (1, '서울', NULL, 'SIDO');
+INSERT INTO region (id, name, parent_id, level) VALUES (2, '부산', NULL, 'SIDO');
+INSERT INTO region (id, name, parent_id, level) VALUES (3, '제주', NULL, 'SIDO');
 
--- 4. 이미지 데이터 (Image)
+-- 4. 부모 테이블 (place) 데이터 삽입
+INSERT INTO place (id, title, address, latitude, longitude) VALUES
+(1, '남산서울타워', '서울 용산구 남산공원길 105', 37.55117, 126.9882),
+(2, '해운대 해수욕장', '부산 해운대구 해운대해변로 264', 35.1587, 129.1604);
+
+-- 4. 자식 장소 테이블 (external_place)
+INSERT INTO external_place (id, description, url, tel, region) VALUES
+(1, '서울의 랜드마크입니다.', 'https://place.com/1', '02-123-4567', 2),
+(2, '여름철 최고의 휴양지입니다.', 'https://place.com/2', '051-987-6543', 1);
+
+-- 5. 이미지 데이터 (Image)
 INSERT INTO image (id, place_id, url, copyright)
 VALUES
 (1, 1, 'https://images.com/namsan1.jpg', '한국관광공사'),
 (2, 1, 'https://images.com/namsan2.jpg', 'ⓒ초코비'),
 (3, 2, 'https://images.com/haeundae.jpg', '부산시청');
 
--- 5. 게시글 데이터 (Post)
-INSERT INTO post (id, place_id, user_id, likes, rating, content, title, created_at, updated_at)
+-- 6. 게시글 데이터 (Post)
+INSERT INTO post (id, place_id, user_id, likes, content, title, created_at, updated_at)
 VALUES
-(1, 1, 12345678, 10, 5, '야경이 정말 예뻐요!', '남산 나들이', NOW(), NOW()),
-(2, 2, 11223344, 5, 4, '사람이 많지만 바다가 깨끗해요.', '부산 여행 후기', NOW(), NOW());
+(1, 1, 12345678, 10, '야경이 정말 예뻐요!', '남산 나들이', NOW(), NOW()),
+(2, 2, 11223344, 5, '사람이 많지만 바다가 깨끗해요.', '부산 여행 후기', NOW(), NOW());
 
--- 6. 여행 계획 (Trip)
+-- 7. 여행 계획 (Trip)
 INSERT INTO trip (id, user_kakao_id, title, status, arrival, departure, carbon_emission, carbon_saved, start_date, end_date, created_at, updated_at)
 VALUES
 (1, 12345678, '서울 힐링 여행', 'COMPLETED', 'SEOUL', 'BUSAN', 12.5, 5.2, '2026-02-01', '2026-02-03', NOW(), NOW()),
 (2, 12345678, '제주 한달살기', 'READY', 'JEJU', 'SEOUL', 45.0, 10.0, '2026-03-01', '2026-03-31', NOW(), NOW());
 
--- 7. 여행지 상세 (Trip Place)
+-- 8. 여행지 상세 (Trip Place)
 INSERT INTO trip_place (id, place_id, trip_id, day_index, visit_order, memo)
 VALUES
 (1, 1, 1, 0, 1, '도착하자마자 가기'),
 (2, 3, 1, 0, 2, '한복 대여해서 사진 찍기');
 
--- 8. 여행 구간 정보 (Trip Segment)
+-- 9. 여행 구간 정보 (Trip Segment)
 INSERT INTO trip_segment (id, trip_id, start_place_id, end_place_id, distance, duration, carbon_emitted, transport, created_at, updated_at)
 VALUES
 (1, 1, 1, 3, 5.2, 20, 1.2, 'BUS', NOW(), NOW());
-
--- 9. 지역 코드 (Area Code)
-INSERT INTO area_code (code, name)
-VALUES
-(1, '서울'), (2, '인천'), (3, '대전'), (4, '대구'), (5, '광주'), (6, '부산'), (7, '울산'), (8, '세종'), (31, '경기');

--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -35,6 +35,7 @@ DROP TABLE IF EXISTS place;
 CREATE TABLE place
 (
     id          bigint PRIMARY KEY,
+    place_type  varchar(31) NOT NULL,
     title       varchar(255) NOT NULL,
     address     varchar(255) NOT NULL,
     latitude    double       NOT NULL,
@@ -51,7 +52,7 @@ CREATE TABLE external_place
     description TEXT,
     tel         varchar(255),
     url         varchar(2000),
-    region      bigint
+    region_id   bigint
 );
 
 DROP TABLE IF EXISTS custom_place;

--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -22,22 +22,42 @@ CREATE TABLE user_device
     updated_at          datetime(6) NOT NULL
 );
 
+DROP TABLE IF EXISTS region;
+CREATE TABLE region
+(
+    id        bigint PRIMARY KEY,
+    name      varchar(100) NOT NULL,
+    parent_id bigint,
+    level     varchar(20)  NOT NULL
+);
+
 DROP TABLE IF EXISTS place;
 CREATE TABLE place
 (
-    id              bigint PRIMARY KEY,
-    latitude        double NOT NULL,
-    longitude       double NOT NULL,
-    url             varchar(2000),
-    address         varchar(255) NOT NULL,
-    copyright       varchar(255),
-    region_detail   varchar(255),
-    tel             varchar(255),
-    title           varchar(255) NOT NULL,
-    category        enum('CULTURE','ETC','EXPERIENCE','FOOD','NATURE'),
-    description     TEXT,
-    region_group    enum('BUSAN','CHUNGBUK','CHUNGNAM','DAEGU','DAEJEON','GANGWON','GWANGJU','GYEONGBUK','GYEONGGI','GYEONGNAM','INCHEON','JEJU','JEONBUK','JEONNAM','SEJONG','SEOUL','ULSAN'),
-    source_type     enum('API','USER')
+    id          bigint PRIMARY KEY,
+    title       varchar(255) NOT NULL,
+    address     varchar(255) NOT NULL,
+    latitude    double       NOT NULL,
+    longitude   double       NOT NULL,
+    copyright   varchar(255),
+    created_at  datetime(6),
+    updated_at  datetime(6)
+);
+
+DROP TABLE IF EXISTS external_place;
+CREATE TABLE external_place
+(
+    id          bigint PRIMARY KEY,
+    description TEXT,
+    tel         varchar(255),
+    url         varchar(2000),
+    region      bigint
+);
+
+DROP TABLE IF EXISTS custom_place;
+CREATE TABLE custom_place
+(
+    id      bigint PRIMARY KEY
 );
 
 DROP TABLE IF EXISTS image;
@@ -126,7 +146,7 @@ CREATE TABLE post_like
     post_id     bigint NOT NULL,
     user_id     bigint NOT NULL,
     created_at  datetime(6) NOT NULL,
-    updated_at  datetime(6) NOT NULL,
+    updated_at  datetime(6) NOT NULL
 );
 
 DROP TABLE IF EXISTS post_comment;
@@ -139,11 +159,4 @@ CREATE TABLE post_comment
     content     varchar(255) NOT NULL,
     created_at  datetime(6)  NOT NULL,
     updated_at  datetime(6)  NOT NULL
-);
-
-DROP TABLE IF EXISTS area_code;
-CREATE TABLE area_code
-(
-    code     int PRIMARY KEY,
-    name     varchar(255)
 );


### PR DESCRIPTION
## 🚨 관련 이슈


## 🚀 작업 목적
- 기존의 단일 ErrorCode 관리 방식에서 도메인별 에러 코드 구조로 분리했습니다.

## 📝 작업 내용 
- `ErrorCode` 인터페이스 정의
  - 상태 코드(HttpStatus)와 메시지(Message)를 공통 인터페이스로 규격화
  - default getCode() 메서드를 통해 Enum 명칭을 에러 코드로 자동 변환

- `GlobalError`, `PostError` 등으로 도메인 별 에러 코드 구조 분리 가능
-  `schema.sql`, `data.sql` 를 변경된 엔티티에 따라 업데이트


## 🖼️ 스크린샷 (선택 사항)

## ✅ 체크리스트
- [ ] 코드 컨벤션을 준수했나요?
- [ ] 불필요한 주석이나 로그를 제거했나요?
- [ ] 테스트를 통과했나요?
- [ ] 변경 사항에 대한 문서를 업데이트했나요?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새 기능**
  * 지역 및 장소 관리를 위한 데이터베이스 구조 개선
  * 외부 장소 및 커스텀 장소 데이터 지원 추가

* **버그 수정**
  * 에러 메시지 처리 체계 개선

* **기타**
  * 한글 기반 에러 메시지 체계 도입
  * 데이터베이스 시드 데이터 확장

<!-- end of auto-generated comment: release notes by coderabbit.ai -->