### PR TITLE
test: add trip domain tests

### DIFF
--- a/src/main/resources/application-test.yml
+++ b/src/main/resources/application-test.yml
@@ -15,3 +15,43 @@ spring:
   sql:
     init:
       mode: never
+
+kakao:
+  admin-key: test-admin-key
+  api:
+    key: test-kakao-api-key
+
+tour:
+  api:
+    key: test-tour-api-key
+
+theme:
+  api:
+    key: test-theme-api-key
+
+rural:
+  api:
+    key: test-rural-api-key
+
+farm:
+  api:
+    key: test-farm-api-key
+
+tmap:
+  api:
+    key: test-tmap-api-key
+
+naver:
+  client:
+    id: test-naver-client-id
+    secret: test-naver-client-secret
+
+jwt:
+  secret: test-jwt-secret-key-for-leafy-tests-1234567890
+  access-token:
+    expiration: 3600000
+  refresh-token:
+    expiration: 1209600000
+
+cookie:
+  secure: false

--- a/src/test/java/com/chocobi/leafy/trip/application/TripServiceTest.java
+++ b/src/test/java/com/chocobi/leafy/trip/application/TripServiceTest.java
@@ -1,0 +1,289 @@
+package com.chocobi.leafy.trip.application;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.never;
+
+import com.chocobi.leafy.global.entity.RegionEntity;
+import com.chocobi.leafy.global.entity.RegionLevel;
+import com.chocobi.leafy.global.exception.CustomException;
+import com.chocobi.leafy.global.service.RegionFindService;
+import com.chocobi.leafy.place.fetcher.kakao.dto.Address;
+import com.chocobi.leafy.trip.client.TransCoordDTO;
+import com.chocobi.leafy.trip.client.TransCoordResponse;
+import com.chocobi.leafy.trip.client.TransDocument;
+import com.chocobi.leafy.trip.client.TranscodeClient;
+import com.chocobi.leafy.trip.dto.request.CreateTripRequest;
+import com.chocobi.leafy.trip.dto.request.TripUpdateRequest;
+import com.chocobi.leafy.trip.dto.response.TripDetailResponse;
+import com.chocobi.leafy.trip.dto.response.TripListResponse;
+import com.chocobi.leafy.trip.dto.response.TripSaveResponse;
+import com.chocobi.leafy.trip.infra.TripCommandService;
+import com.chocobi.leafy.trip.infra.TripFindService;
+import com.chocobi.leafy.trip.infra.entity.TripEntity;
+import com.chocobi.leafy.trip.infra.entity.TripStatus;
+import com.chocobi.leafy.trip.vo.TripError;
+import com.chocobi.leafy.user.infra.entity.UserEntity;
+import com.chocobi.leafy.user.infra.entity.enums.Provider;
+import com.chocobi.leafy.user.infra.service.UserService;
+import java.time.LocalDate;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@ExtendWith(MockitoExtension.class)
+class TripServiceTest {
+
+    @InjectMocks
+    private TripService tripService;
+
+    @Mock
+    private TripFindService tripFindService;
+
+    @Mock
+    private TripCommandService tripCommandService;
+
+    @Mock
+    private UserService userService;
+
+    @Mock
+    private TripPlaceService tripPlaceService;
+
+    @Mock
+    private TripSegmentService tripSegmentService;
+
+    @Mock
+    private TranscodeClient transcodeClient;
+
+    @Mock
+    private RegionFindService regionFindService;
+
+    @Test
+    @DisplayName("여행을 생성한다")
+    void createTrip() {
+        UserEntity user = userFixture(1L);
+        RegionEntity seoul = regionFixture(10L, "서울");
+        RegionEntity busan = regionFixture(20L, "부산");
+        CreateTripRequest request = new CreateTripRequest(
+                "부산 여행",
+                LocalDate.of(2026, 6, 1),
+                LocalDate.of(2026, 6, 3),
+                "서울",
+                "부산"
+        );
+
+        given(regionFindService.findRegion("서울")).willReturn(seoul);
+        given(regionFindService.findRegion("부산")).willReturn(busan);
+        given(userService.findById(1L)).willReturn(user);
+        given(tripCommandService.save(any(TripEntity.class))).willAnswer(invocation -> {
+            TripEntity trip = invocation.getArgument(0);
+            ReflectionTestUtils.setField(trip, "id", 100L);
+            return trip;
+        });
+
+        TripSaveResponse result = tripService.createTrip(request, 1L);
+
+        assertThat(result.getTripId()).isEqualTo(100L);
+        assertThat(result.getStatus()).isEqualTo(TripStatus.CREATING);
+
+        ArgumentCaptor<TripEntity> tripCaptor = ArgumentCaptor.forClass(TripEntity.class);
+        then(tripCommandService).should().save(tripCaptor.capture());
+        TripEntity savedTrip = tripCaptor.getValue();
+        assertThat(savedTrip.getUser()).isEqualTo(user);
+        assertThat(savedTrip.getDeparture()).isEqualTo(seoul);
+        assertThat(savedTrip.getArrival()).isEqualTo(busan);
+        assertThat(savedTrip.getTitle()).isEqualTo("부산 여행");
+    }
+
+    @Test
+    @DisplayName("사용자의 여행 목록을 응답 DTO로 변환한다")
+    void getTrips() {
+        given(tripFindService.findTripsByUserId(1L))
+                .willReturn(List.of(tripFixture(10L, userFixture(1L), "부산 여행")));
+
+        List<TripListResponse> result = tripService.getTrips(1L);
+
+        assertThat(result).hasSize(1);
+        assertThat(result.getFirst().getTripId()).isEqualTo(10L);
+        assertThat(result.getFirst().getTitle()).isEqualTo("부산 여행");
+    }
+
+    @Test
+    @DisplayName("여행 상세 정보를 수정한다")
+    void updateTripInfo() {
+        TripEntity trip = tripFixture(10L, userFixture(1L), "기존 여행");
+        TripUpdateRequest request = new TripUpdateRequest(
+                "수정된 여행",
+                LocalDate.of(2026, 7, 1),
+                LocalDate.of(2026, 7, 2)
+        );
+
+        given(tripFindService.findOwnedTripDetail(10L, 1L)).willReturn(trip);
+        given(tripSegmentService.getTripSegments(10L)).willReturn(List.of());
+
+        TripDetailResponse result = tripService.updateTripInfo(10L, request, 1L);
+
+        assertThat(result.getTitle()).isEqualTo("수정된 여행");
+        assertThat(result.getStartDate()).isEqualTo(LocalDate.of(2026, 7, 1));
+        assertThat(result.getEndDate()).isEqualTo(LocalDate.of(2026, 7, 2));
+        then(tripFindService).should().findOwnedTripDetail(10L, 1L);
+    }
+
+    @Test
+    @DisplayName("여행 삭제 시 소유권을 검증하고 연관 데이터를 먼저 삭제한다")
+    void deleteTrip() {
+        TripEntity trip = tripFixture(10L, userFixture(1L), "삭제할 여행");
+        given(tripFindService.findOwnedTrip(10L, 1L)).willReturn(trip);
+
+        tripService.deleteTrip(10L, 1L);
+
+        then(tripFindService).should().findOwnedTrip(10L, 1L);
+        then(tripSegmentService).should().deleteTripSegments(trip);
+        then(tripPlaceService).should().deleteTripPlaces(trip);
+        then(tripCommandService).should().delete(trip);
+    }
+
+    @Test
+    @DisplayName("진행 중인 여행을 도착 지역에서 인증한다")
+    void certifyTrip() {
+        TripEntity trip = tripFixture(10L, userFixture(1L), "부산 여행");
+        trip.editStatus(TripStatus.IN_PROGRESS);
+        RegionEntity busan = regionFixture(20L, "부산");
+        ReflectionTestUtils.setField(trip, "arrival", busan);
+
+        TransCoordDTO coord = transCoordFixture();
+        given(tripFindService.findOwnedTrip(10L, 1L)).willReturn(trip);
+        given(transcodeClient.requestGeocode(coord)).willReturn(transCoordResponse("부산"));
+        given(regionFindService.findRegion("부산")).willReturn(busan);
+
+        tripService.certifyTrip(10L, coord, 1L);
+
+        assertThat(trip.getCertificationAt()).isNotNull();
+        then(tripCommandService).should().save(trip);
+    }
+
+    @Test
+    @DisplayName("진행 중인 여행이 아니면 인증할 수 없다")
+    void certifyTrip_NotInProgress() {
+        TripEntity trip = tripFixture(10L, userFixture(1L), "부산 여행");
+        TransCoordDTO coord = transCoordFixture();
+        given(tripFindService.findOwnedTrip(10L, 1L)).willReturn(trip);
+
+        assertThatThrownBy(() -> tripService.certifyTrip(10L, coord, 1L))
+                .isInstanceOf(CustomException.class)
+                .extracting("errorCode")
+                .isEqualTo(TripError.TRIP_NOT_IN_PROGRESS);
+
+        then(transcodeClient).should(never()).requestGeocode(any());
+        then(tripCommandService).should(never()).save(any());
+    }
+
+    @Test
+    @DisplayName("현재 위치의 지역을 알 수 없으면 인증할 수 없다")
+    void certifyTrip_LocationUnavailable() {
+        TripEntity trip = tripFixture(10L, userFixture(1L), "부산 여행");
+        trip.editStatus(TripStatus.IN_PROGRESS);
+        TransCoordDTO coord = transCoordFixture();
+        TransCoordResponse emptyResponse = new TransCoordResponse();
+        emptyResponse.setDocuments(List.of());
+
+        given(tripFindService.findOwnedTrip(10L, 1L)).willReturn(trip);
+        given(transcodeClient.requestGeocode(coord)).willReturn(emptyResponse);
+
+        assertThatThrownBy(() -> tripService.certifyTrip(10L, coord, 1L))
+                .isInstanceOf(CustomException.class)
+                .extracting("errorCode")
+                .isEqualTo(TripError.TRIP_LOCATION_UNAVAILABLE);
+
+        then(tripCommandService).should(never()).save(any());
+    }
+
+    @Test
+    @DisplayName("현재 위치가 도착 지역과 다르면 인증할 수 없다")
+    void certifyTrip_LocationMismatch() {
+        TripEntity trip = tripFixture(10L, userFixture(1L), "부산 여행");
+        trip.editStatus(TripStatus.IN_PROGRESS);
+        ReflectionTestUtils.setField(trip, "arrival", regionFixture(20L, "부산"));
+
+        TransCoordDTO coord = transCoordFixture();
+        given(tripFindService.findOwnedTrip(10L, 1L)).willReturn(trip);
+        given(transcodeClient.requestGeocode(coord)).willReturn(transCoordResponse("서울"));
+        given(regionFindService.findRegion("서울")).willReturn(regionFixture(30L, "서울"));
+
+        assertThatThrownBy(() -> tripService.certifyTrip(10L, coord, 1L))
+                .isInstanceOf(CustomException.class)
+                .extracting("errorCode")
+                .isEqualTo(TripError.TRIP_LOCATION_MISMATCH);
+
+        then(tripCommandService).should(never()).save(any());
+    }
+
+    @Test
+    @DisplayName("스케줄러용 여행 상태를 변경한다")
+    void changeTripStatusForScheduler() {
+        TripEntity trip = tripFixture(10L, userFixture(1L), "부산 여행");
+        given(tripFindService.findTrip(10L)).willReturn(trip);
+
+        tripService.changeTripStatusForScheduler(10L, TripStatus.IN_PROGRESS);
+
+        assertThat(trip.getStatus()).isEqualTo(TripStatus.IN_PROGRESS);
+    }
+
+    private TripEntity tripFixture(Long tripId, UserEntity user, String title) {
+        TripEntity trip = TripEntity.builder()
+                .user(user)
+                .title(title)
+                .startDate(LocalDate.of(2026, 6, 1))
+                .endDate(LocalDate.of(2026, 6, 3))
+                .departure(regionFixture(10L, "서울"))
+                .arrival(regionFixture(20L, "부산"))
+                .build();
+        ReflectionTestUtils.setField(trip, "id", tripId);
+        return trip;
+    }
+
+    private UserEntity userFixture(Long userId) {
+        UserEntity user = UserEntity.builder()
+                .nickname("테스터")
+                .profileImageUrl("https://example.com/profile.png")
+                .provider(Provider.KAKAO)
+                .providerId("provider-" + userId)
+                .build();
+        ReflectionTestUtils.setField(user, "id", userId);
+        return user;
+    }
+
+    private RegionEntity regionFixture(Long regionId, String name) {
+        RegionEntity region = new RegionEntity(name, null, RegionLevel.SIDO);
+        ReflectionTestUtils.setField(region, "id", regionId);
+        return region;
+    }
+
+    private TransCoordDTO transCoordFixture() {
+        TransCoordDTO coord = new TransCoordDTO();
+        coord.setX("129.0756");
+        coord.setY("35.1796");
+        return coord;
+    }
+
+    private TransCoordResponse transCoordResponse(String regionName) {
+        Address address = new Address();
+        address.setRegion_1depth_name(regionName);
+
+        TransDocument document = new TransDocument();
+        document.setAddress(address);
+
+        TransCoordResponse response = new TransCoordResponse();
+        response.setDocuments(List.of(document));
+        return response;
+    }
+}

--- a/src/test/java/com/chocobi/leafy/trip/infra/TripFindServiceTest.java
+++ b/src/test/java/com/chocobi/leafy/trip/infra/TripFindServiceTest.java
@@ -1,0 +1,122 @@
+package com.chocobi.leafy.trip.infra;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.chocobi.leafy.global.entity.RegionEntity;
+import com.chocobi.leafy.global.entity.RegionLevel;
+import com.chocobi.leafy.global.entity.RegionRepository;
+import com.chocobi.leafy.global.exception.CustomException;
+import com.chocobi.leafy.trip.infra.entity.TripEntity;
+import com.chocobi.leafy.trip.infra.repository.TripRepository;
+import com.chocobi.leafy.trip.vo.TripError;
+import com.chocobi.leafy.user.infra.entity.UserEntity;
+import com.chocobi.leafy.user.infra.entity.enums.Provider;
+import com.chocobi.leafy.user.infra.repository.UserRepository;
+import java.time.LocalDate;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ActiveProfiles;
+
+@DataJpaTest
+@Import(TripFindService.class)
+@ActiveProfiles("test")
+class TripFindServiceTest {
+
+    @Autowired
+    private TripFindService tripFindService;
+
+    @Autowired
+    private TripRepository tripRepository;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private RegionRepository regionRepository;
+
+    @Test
+    @DisplayName("존재하는 여행을 조회한다")
+    void findTrip() {
+        TripEntity trip = saveTrip("부산 여행", saveUser("user-1"));
+
+        TripEntity result = tripFindService.findTrip(trip.getId());
+
+        assertThat(result.getId()).isEqualTo(trip.getId());
+        assertThat(result.getTitle()).isEqualTo("부산 여행");
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 여행이면 예외가 발생한다")
+    void findTrip_NotFound() {
+        assertThatThrownBy(() -> tripFindService.findTrip(999L))
+                .isInstanceOf(CustomException.class)
+                .extracting("errorCode")
+                .isEqualTo(TripError.TRIP_NOT_FOUND);
+    }
+
+    @Test
+    @DisplayName("내 여행을 조회한다")
+    void findOwnedTrip() {
+        UserEntity user = saveUser("user-1");
+        TripEntity trip = saveTrip("내 여행", user);
+
+        TripEntity result = tripFindService.findOwnedTrip(trip.getId(), user.getId());
+
+        assertThat(result.getId()).isEqualTo(trip.getId());
+    }
+
+    @Test
+    @DisplayName("다른 사용자의 여행이면 접근 거부 예외가 발생한다")
+    void findOwnedTrip_AccessDenied() {
+        TripEntity trip = saveTrip("다른 사용자 여행", saveUser("owner"));
+        UserEntity otherUser = saveUser("other");
+
+        assertThatThrownBy(() -> tripFindService.findOwnedTrip(trip.getId(), otherUser.getId()))
+                .isInstanceOf(CustomException.class)
+                .extracting("errorCode")
+                .isEqualTo(TripError.TRIP_ACCESS_DENIED);
+    }
+
+    @Test
+    @DisplayName("사용자별 여행 목록을 최신 생성순으로 조회한다")
+    void findTripsByUserId() {
+        UserEntity user = saveUser("user-1");
+        UserEntity otherUser = saveUser("other");
+        saveTrip("첫 번째 여행", user);
+        saveTrip("다른 사용자 여행", otherUser);
+        saveTrip("두 번째 여행", user);
+
+        List<TripEntity> result = tripFindService.findTripsByUserId(user.getId());
+
+        assertThat(result).extracting(TripEntity::getTitle)
+                .containsExactly("두 번째 여행", "첫 번째 여행");
+    }
+
+    private TripEntity saveTrip(String title, UserEntity user) {
+        RegionEntity departure = regionRepository.saveAndFlush(new RegionEntity(title + " 출발", null, RegionLevel.SIDO));
+        RegionEntity arrival = regionRepository.saveAndFlush(new RegionEntity(title + " 도착", null, RegionLevel.SIDO));
+
+        return tripRepository.saveAndFlush(TripEntity.builder()
+                .user(user)
+                .title(title)
+                .startDate(LocalDate.of(2026, 6, 1))
+                .endDate(LocalDate.of(2026, 6, 3))
+                .departure(departure)
+                .arrival(arrival)
+                .build());
+    }
+
+    private UserEntity saveUser(String providerId) {
+        return userRepository.saveAndFlush(UserEntity.builder()
+                .nickname("테스터" + providerId)
+                .profileImageUrl("https://example.com/profile.png")
+                .provider(Provider.KAKAO)
+                .providerId(providerId)
+                .build());
+    }
+}

--- a/src/test/java/com/chocobi/leafy/trip/presentation/TripControllerTest.java
+++ b/src/test/java/com/chocobi/leafy/trip/presentation/TripControllerTest.java
@@ -1,0 +1,206 @@
+package com.chocobi.leafy.trip.presentation;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.chocobi.leafy.auth.filter.JwtAuthenticationFilter;
+import com.chocobi.leafy.trip.dto.request.CreateTripRequest;
+import com.chocobi.leafy.trip.dto.request.TripUpdateRequest;
+import com.chocobi.leafy.trip.dto.response.TripDetailResponse;
+import com.chocobi.leafy.trip.dto.response.TripListResponse;
+import com.chocobi.leafy.trip.dto.response.TripSaveResponse;
+import com.chocobi.leafy.trip.application.TripService;
+import com.chocobi.leafy.trip.infra.entity.TripStatus;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.time.LocalDate;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.data.jpa.mapping.JpaMetamodelMappingContext;
+import org.springframework.http.MediaType;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(TripController.class)
+@AutoConfigureMockMvc(addFilters = false)
+class TripControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @MockBean
+    private TripService tripService;
+
+    @MockBean
+    private JwtAuthenticationFilter jwtAuthenticationFilter;
+
+    @MockBean
+    private JpaMetamodelMappingContext jpaMetamodelMappingContext;
+
+    @Test
+    @DisplayName("여행을 생성한다")
+    void createTrip() throws Exception {
+        CreateTripRequest request = new CreateTripRequest(
+                "부산 여행",
+                LocalDate.of(2026, 6, 1),
+                LocalDate.of(2026, 6, 3),
+                "서울",
+                "부산"
+        );
+        given(tripService.createTrip(any(CreateTripRequest.class), eq(1L)))
+                .willReturn(TripSaveResponse.builder()
+                        .tripId(10L)
+                        .status(TripStatus.CREATING)
+                        .build());
+
+        mockMvc.perform(post("/api/trip")
+                        .principal(authentication())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.code").value("SUCCESS"))
+                .andExpect(jsonPath("$.data.tripId").value(10))
+                .andExpect(jsonPath("$.data.status").value("CREATING"));
+
+        then(tripService).should().createTrip(any(CreateTripRequest.class), eq(1L));
+    }
+
+    @Test
+    @DisplayName("여행 생성 요청의 제목이 비어 있으면 400을 반환한다")
+    void createTrip_InvalidTitle() throws Exception {
+        CreateTripRequest request = new CreateTripRequest(
+                "",
+                LocalDate.of(2026, 6, 1),
+                LocalDate.of(2026, 6, 3),
+                "서울",
+                "부산"
+        );
+
+        mockMvc.perform(post("/api/trip")
+                        .principal(authentication())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @DisplayName("여행 생성 요청의 종료일이 시작일보다 빠르면 400을 반환한다")
+    void createTrip_InvalidDateRange() throws Exception {
+        CreateTripRequest request = new CreateTripRequest(
+                "부산 여행",
+                LocalDate.of(2026, 6, 3),
+                LocalDate.of(2026, 6, 1),
+                "서울",
+                "부산"
+        );
+
+        mockMvc.perform(post("/api/trip")
+                        .principal(authentication())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @DisplayName("여행 목록을 조회한다")
+    void getTrips() throws Exception {
+        given(tripService.getTrips(1L))
+                .willReturn(List.of(TripListResponse.builder()
+                        .tripId(10L)
+                        .title("부산 여행")
+                        .startDate(LocalDate.of(2026, 6, 1))
+                        .endDate(LocalDate.of(2026, 6, 3))
+                        .status(TripStatus.CREATING)
+                        .build()));
+
+        mockMvc.perform(get("/api/trip")
+                        .principal(authentication()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data[0].tripId").value(10))
+                .andExpect(jsonPath("$.data[0].title").value("부산 여행"));
+
+        then(tripService).should().getTrips(1L);
+    }
+
+    @Test
+    @DisplayName("여행 상세를 조회한다")
+    void getTripDetails() throws Exception {
+        given(tripService.getTripDetails(10L, 1L))
+                .willReturn(TripDetailResponse.builder()
+                        .tripId(10L)
+                        .title("부산 여행")
+                        .status(TripStatus.CREATING)
+                        .build());
+
+        mockMvc.perform(get("/api/trip/{tripId}", 10L)
+                        .principal(authentication()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.tripId").value(10))
+                .andExpect(jsonPath("$.data.title").value("부산 여행"));
+
+        then(tripService).should().getTripDetails(10L, 1L);
+    }
+
+    @Test
+    @DisplayName("여행 ID가 양수가 아니면 400을 반환한다")
+    void getTripDetails_InvalidTripId() throws Exception {
+        mockMvc.perform(get("/api/trip/{tripId}", 0L)
+                        .principal(authentication()))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @DisplayName("여행을 삭제한다")
+    void deleteTrip() throws Exception {
+        mockMvc.perform(delete("/api/trip/{tripId}", 10L)
+                        .principal(authentication()))
+                .andExpect(status().isNoContent());
+
+        then(tripService).should().deleteTrip(10L, 1L);
+    }
+
+    @Test
+    @DisplayName("여행 정보를 수정한다")
+    void updateTrip() throws Exception {
+        TripUpdateRequest request = new TripUpdateRequest(
+                "수정된 여행",
+                LocalDate.of(2026, 7, 1),
+                LocalDate.of(2026, 7, 2)
+        );
+        given(tripService.updateTripInfo(eq(10L), any(TripUpdateRequest.class), eq(1L)))
+                .willReturn(TripDetailResponse.builder()
+                        .tripId(10L)
+                        .title("수정된 여행")
+                        .status(TripStatus.CREATING)
+                        .build());
+
+        mockMvc.perform(patch("/api/trip/{tripId}", 10L)
+                        .principal(authentication())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.title").value("수정된 여행"));
+
+        then(tripService).should().updateTripInfo(eq(10L), any(TripUpdateRequest.class), eq(1L));
+    }
+
+    private Authentication authentication() {
+        return new UsernamePasswordAuthenticationToken(1L, null, List.of());
+    }
+}


### PR DESCRIPTION
## 🚨 관련 이슈
- #92 

## 🚀 작업 목적
Trip 도메인 핵심 흐름에 대한 테스트 코드를 추가하여 여행 조회, 생성, 수정, 삭제, 인증, API 요청/응답 동작을 안정적으로 검증하기 위함입니다.

## 📝 작업 내용 
- `TripFindServiceTest` 추가
  - 여행 단건 조회
  - 존재하지 않는 여행 예외 처리
  - 소유자 여행 조회
  - 다른 사용자 여행 접근 거부
  - 사용자별 여행 목록 최신순 조회 검증

- `TripServiceTest` 추가
  - 여행 생성
  - 여행 목록 DTO 변환
  - 여행 정보 수정
  - 여행 삭제 시 소유권 조회 및 연관 데이터 삭제 호출 검증
  - 여행 인증 성공/실패 케이스 검증
  - 스케줄러용 여행 상태 변경 검증

- `TripControllerTest` 추가
  - 여행 생성, 목록 조회, 상세 조회, 삭제, 수정 API 테스트
  - 요청 validation 실패 시 400 응답 검증
  - 인증 principal의 userId가 서비스로 전달되는지 검증

- `application-test.yml` 테스트 설정 보완
  - 테스트 실행 시 필요한 더미 설정값 추가
  - 외부 환경변수 없이 테스트가 실행될 수 있도록 구성

## 🖼️ 스크린샷 (선택 사항)

## ✅ 체크리스트
- [x] 코드 컨벤션을 준수했나요?
- [x] 불필요한 주석이나 로그를 제거했나요?
- [x] 테스트를 통과했나요?
- [ ] 변경 사항에 대한 문서를 업데이트했나요?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Tests**
  * 여행 생성, 조회, 수정, 삭제 및 인증 기능에 대한 서비스 계층 테스트 추가
  * 여행 조회 기능의 저장소 통합 테스트 추가
  * 여행 API 엔드포인트의 컨트롤러 테스트 추가

* **Chores**
  * 테스트 환경 설정 및 외부 서비스 연동 설정값 추가

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Chocobi25/Leafy/pull/94?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->