### PR TITLE
feat: 브이월드 API 기반 지역 데이터 초기 적재 추가

### DIFF
--- a/src/main/java/com/chocobi/leafy/config/WebClientConfig.java
+++ b/src/main/java/com/chocobi/leafy/config/WebClientConfig.java
@@ -72,6 +72,11 @@ public class WebClientConfig {
                 .build();
     }
 
+    @Bean
+    public WebClient vWorldClient(@Value("${VWORLD_API_URL}") String vWorldUrl) {
+        return createWebClient(vWorldUrl);
+    }
+
 
     private WebClient createWebClient(String baseUrl) {
         return WebClient.builder()

--- a/src/main/java/com/chocobi/leafy/external/vworld/client/VWorldRegionClient.java
+++ b/src/main/java/com/chocobi/leafy/external/vworld/client/VWorldRegionClient.java
@@ -1,0 +1,121 @@
+package com.chocobi.leafy.external.vworld.client;
+
+import com.chocobi.leafy.external.vworld.dto.VWorldRegionResponse;
+import com.chocobi.leafy.external.vworld.dto.VWorldRegionResponse.VWorldRegionItem;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.client.WebClient;
+import org.springframework.web.util.UriComponentsBuilder;
+import reactor.util.retry.Retry;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class VWorldRegionClient {
+    private static final String ADM_CODE_LIST_PATH = "/admCodeList";
+    private static final String ADM_SI_LIST_PATH = "/admSiList";
+    private static final String ADM_EMD_LIST_PATH = "/admDongList";
+    private static final String ADM_REE_LIST_PATH = "/admReeList";
+    private static final int PAGE_SIZE = 100;
+
+    private final WebClient vWorldClient;
+
+    @Value("${VWORLD_API_KEY}")
+    private String apiKey;
+
+    @Value("${SERVICE_DOMAIN_URL}")
+    private String serviceDomain;
+
+    public List<VWorldRegionItem> fetchSidos() {
+        return fetchAllPages(ADM_CODE_LIST_PATH, null);
+    }
+
+    public List<VWorldRegionItem> fetchSigungus(String sidoCode) {
+        return fetchAllPages(ADM_SI_LIST_PATH, sidoCode);
+    }
+
+    public List<VWorldRegionItem> fetchEmds(String sigunguCode) {
+        return fetchAllPages(ADM_EMD_LIST_PATH, sigunguCode);
+    }
+
+    public List<VWorldRegionItem> fetchRees(String emdCode) {
+        return fetchAllPages(ADM_REE_LIST_PATH, emdCode);
+    }
+
+    private List<VWorldRegionItem> fetchAllPages(String path, String admCode) {
+        List<VWorldRegionItem> accumulated = new ArrayList<>();
+
+        VWorldRegionResponse firstResponse = fetchPage(path, admCode, 1);
+        List<VWorldRegionItem> firstPage = extractItems(firstResponse);
+
+        if (firstPage.isEmpty()) {
+            return accumulated;
+        }
+
+        accumulated.addAll(firstPage);
+
+        int totalPages = calculateTotalPages(extractTotalCount(firstResponse));
+
+        for (int pageNo = 2; pageNo <= totalPages; pageNo++) {
+            VWorldRegionResponse response = fetchPage(path, admCode, pageNo);
+            accumulated.addAll(extractItems(response));
+        }
+
+        return accumulated;
+    }
+
+    private int calculateTotalPages(int totalCount) {
+        if (totalCount <= 0) {
+            return 1;
+        }
+
+        return (int) Math.ceil((double) totalCount / PAGE_SIZE);
+    }
+
+    private List<VWorldRegionItem> extractItems(VWorldRegionResponse response) {
+        if (response == null || response.getAdmVOList() == null || response.getAdmVOList().getAdmVOList() == null) {
+            return List.of();
+        }
+
+        return response.getAdmVOList().getAdmVOList();
+    }
+
+    private int extractTotalCount(VWorldRegionResponse response) {
+        if (response == null || response.getAdmVOList() == null || response.getAdmVOList().getTotalCount() == null) {
+            return 0;
+        }
+
+        try {
+            return Integer.parseInt(response.getAdmVOList().getTotalCount());
+        } catch (NumberFormatException e) {
+            log.warn("VWorld totalCount 파싱 실패: {}", response.getAdmVOList().getTotalCount());
+            return 0;
+        }
+    }
+
+    private VWorldRegionResponse fetchPage(String endpoint, String admCode, int pageNo) {
+        UriComponentsBuilder uriBuilder = UriComponentsBuilder
+                .fromPath(endpoint)
+                .queryParam("key", apiKey)
+                .queryParam("pageNo", pageNo)
+                .queryParam("numOfRows", PAGE_SIZE)
+                .queryParam("domain", serviceDomain)
+                .queryParam("format", "json");
+
+        if (admCode != null && !admCode.isEmpty()) {
+            uriBuilder.queryParam("admCode", admCode);
+        }
+
+        return vWorldClient.get()
+                .uri(uriBuilder.toUriString())
+                .retrieve()
+                .bodyToMono(VWorldRegionResponse.class)
+                .retryWhen(Retry.backoff(3, Duration.ofSeconds(1)))
+                .block();
+    }
+}

--- a/src/main/java/com/chocobi/leafy/external/vworld/dto/VWorldRegionResponse.java
+++ b/src/main/java/com/chocobi/leafy/external/vworld/dto/VWorldRegionResponse.java
@@ -1,0 +1,25 @@
+package com.chocobi.leafy.external.vworld.dto;
+
+import java.util.List;
+import lombok.Getter;
+
+@Getter
+public class VWorldRegionResponse {
+    private AdmVOList admVOList;
+
+    @Getter
+    public static class AdmVOList {
+        private List<VWorldRegionItem> admVOList;
+        private String totalCount;
+        private String numOfRows;
+        private String error;
+        private String message;
+    }
+
+    @Getter
+    public static class VWorldRegionItem {
+        private String admCode;
+        private String admCodeNm;
+        private String lowestAdmCodeNm;
+    }
+}

--- a/src/main/java/com/chocobi/leafy/global/entity/RegionEntity.java
+++ b/src/main/java/com/chocobi/leafy/global/entity/RegionEntity.java
@@ -12,6 +12,7 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -24,8 +25,14 @@ public class RegionEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
+    @Column(nullable = false)
+    private String code;
+
     @Column(nullable = false, length = 100)
     private String name;
+
+    @Column(nullable = false, length = 200)
+    private String fullName;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "parent_id")
@@ -35,8 +42,11 @@ public class RegionEntity {
     @Column(nullable = false, length = 20)
     private RegionLevel level;
 
-    public RegionEntity(String name, RegionEntity parent, RegionLevel level) {
+    @Builder
+    public RegionEntity(String code, String name, String fullName, RegionEntity parent, RegionLevel level) {
+        this.code = code;
         this.name = name;
+        this.fullName = fullName;
         this.parent = parent;
         this.level = level;
     }

--- a/src/main/java/com/chocobi/leafy/global/entity/RegionLevel.java
+++ b/src/main/java/com/chocobi/leafy/global/entity/RegionLevel.java
@@ -9,7 +9,7 @@ public enum RegionLevel {
     SIDO(1, "시도"),
     SIGUNGU(2, "시군구"),
     EMD(3, "읍면동"),
-    RI(4, "리");
+    REE(4, "리");
 
     private final int depth;
     private final String description;

--- a/src/main/java/com/chocobi/leafy/global/entity/RegionRepository.java
+++ b/src/main/java/com/chocobi/leafy/global/entity/RegionRepository.java
@@ -1,9 +1,11 @@
 package com.chocobi.leafy.global.entity;
 
+import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface RegionRepository extends JpaRepository<RegionEntity, Long> {
     Optional<RegionEntity> findByName(String name);
     Optional<RegionEntity> findByNameAndLevel(String name, RegionLevel level);
+    List<RegionEntity> findByLevel(RegionLevel level);
 }

--- a/src/main/java/com/chocobi/leafy/global/service/RegionCommandService.java
+++ b/src/main/java/com/chocobi/leafy/global/service/RegionCommandService.java
@@ -1,0 +1,23 @@
+package com.chocobi.leafy.global.service;
+
+import com.chocobi.leafy.global.entity.RegionEntity;
+import com.chocobi.leafy.global.entity.RegionRepository;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class RegionCommandService {
+    private final RegionRepository regionRepository;
+
+    public void save(RegionEntity region) {
+        regionRepository.save(region);
+    }
+
+    public List<RegionEntity> saveAll(List<RegionEntity> regions) {
+        return regionRepository.saveAll(regions);
+    }
+}

--- a/src/main/java/com/chocobi/leafy/global/service/RegionFindService.java
+++ b/src/main/java/com/chocobi/leafy/global/service/RegionFindService.java
@@ -1,6 +1,7 @@
 package com.chocobi.leafy.global.service;
 
 import com.chocobi.leafy.global.entity.RegionEntity;
+import com.chocobi.leafy.global.entity.RegionLevel;
 import com.chocobi.leafy.global.entity.RegionRepository;
 import com.chocobi.leafy.global.exception.CustomException;
 import com.chocobi.leafy.global.exception.GlobalError;
@@ -22,10 +23,19 @@ public class RegionFindService {
     }
 
     public RegionEntity findRegion(Long id) {
-        return regionRepository.findById(id).orElse(null);
+        return regionRepository.findById(id)
+                .orElseThrow(() -> new CustomException(GlobalError.REGION_NOT_FOUND));
+    }
+
+    public List<RegionEntity> findRegions(RegionLevel level) {
+        return regionRepository.findByLevel(level);
     }
 
     public List<RegionEntity> findRegions() {
         return regionRepository.findAll();
+    }
+
+    public long findRegionCount() {
+        return regionRepository.count();
     }
 }

--- a/src/main/java/com/chocobi/leafy/global/service/RegionInitializer.java
+++ b/src/main/java/com/chocobi/leafy/global/service/RegionInitializer.java
@@ -13,7 +13,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.boot.context.event.ApplicationReadyEvent;
 import org.springframework.context.event.EventListener;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
 @Slf4j
 @Service
@@ -24,9 +23,8 @@ public class RegionInitializer {
     private final RegionFindService regionFindService;
 
     @EventListener(ApplicationReadyEvent.class)
-    @Transactional
     public void initRegions() {
-        if (regionFindService.findRegionCount() > 0) {
+        if (isAllRegionLevelsInitialized()) {
             log.info("이미 지역 데이터가 존재합니다.");
             return;
         }
@@ -41,7 +39,6 @@ public class RegionInitializer {
         log.info("행정구역 데이터 초기화 완료");
     }
 
-    @Transactional
     public void initSido() {
         initRegionLevel(
                 RegionLevel.SIDO,
@@ -49,7 +46,6 @@ public class RegionInitializer {
         );
     }
 
-    @Transactional
     public void initSigungu() {
         initRegionLevel(
                 RegionLevel.SIGUNGU,
@@ -57,7 +53,6 @@ public class RegionInitializer {
         );
     }
 
-    @Transactional
     public void initDong() {
         initRegionLevel(
                 RegionLevel.EMD,
@@ -65,7 +60,6 @@ public class RegionInitializer {
         );
     }
 
-    @Transactional
     public void initRee() {
         initRegionLevel(
                 RegionLevel.REE,
@@ -74,6 +68,11 @@ public class RegionInitializer {
     }
 
     private void initRegionLevel(RegionLevel level, RegionLevel parentLevel) {
+        if (isRegionLevelInitialized(level)) {
+            log.info("{} 데이터가 이미 존재합니다. 초기화를 건너뜁니다.", level.getDescription());
+            return;
+        }
+
         log.info("{} 데이터 초기화 시작", level.getDescription());
 
         List<VWorldRegionItem> items;
@@ -83,9 +82,8 @@ public class RegionInitializer {
         } else {
             List<RegionEntity> parentRegions = regionFindService.findRegions(parentLevel);
             if (parentRegions.isEmpty()) {
-                log.warn("{} 데이터가 없습니다. 먼저 {} 데이터를 초기화해주세요.",
-                        parentLevel.getDescription(), parentLevel.getDescription());
-                return;
+                throw new IllegalStateException(parentLevel.getDescription() + " 데이터가 없어 "
+                        + level.getDescription() + " 데이터를 초기화할 수 없습니다.");
             }
 
             items = fetchChildRegions(level, parentRegions);
@@ -93,6 +91,17 @@ public class RegionInitializer {
 
         int count = saveRegionsWithParent(items, level, parentLevel);
         log.info("{} 데이터 {}건 저장 완료", level.getDescription(), count);
+    }
+
+    private boolean isAllRegionLevelsInitialized() {
+        return isRegionLevelInitialized(RegionLevel.SIDO)
+                && isRegionLevelInitialized(RegionLevel.SIGUNGU)
+                && isRegionLevelInitialized(RegionLevel.EMD)
+                && isRegionLevelInitialized(RegionLevel.REE);
+    }
+
+    private boolean isRegionLevelInitialized(RegionLevel level) {
+        return !regionFindService.findRegions(level).isEmpty();
     }
 
     private List<VWorldRegionItem> fetchChildRegions(RegionLevel level, List<RegionEntity> parentRegions) {
@@ -120,11 +129,15 @@ public class RegionInitializer {
                 if (e instanceof InterruptedException) {
                     Thread.currentThread().interrupt();
                     log.warn("{} 조회 중 인터럽트 발생 ({}번째, code: {})", parent.getName(), count, parent.getCode());
-                    break;
+                    throw new IllegalStateException(level.getDescription() + " 데이터 초기화가 중단되었습니다.", e);
                 }
 
-                log.warn("{} 조회 실패 ({}번째, code: {}): {}",
-                        parent.getName(), count, parent.getCode(), e.getMessage());
+                throw new IllegalStateException(String.format(
+                        "%s 데이터 초기화 중 %s 하위 지역 조회 실패 (code: %s)",
+                        level.getDescription(),
+                        parent.getName(),
+                        parent.getCode()
+                ), e);
             }
         }
 

--- a/src/main/java/com/chocobi/leafy/global/service/RegionInitializer.java
+++ b/src/main/java/com/chocobi/leafy/global/service/RegionInitializer.java
@@ -1,0 +1,198 @@
+package com.chocobi.leafy.global.service;
+
+import com.chocobi.leafy.external.vworld.client.VWorldRegionClient;
+import com.chocobi.leafy.external.vworld.dto.VWorldRegionResponse.VWorldRegionItem;
+import com.chocobi.leafy.global.entity.RegionEntity;
+import com.chocobi.leafy.global.entity.RegionLevel;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.HashMap;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.context.event.ApplicationReadyEvent;
+import org.springframework.context.event.EventListener;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class RegionInitializer {
+    private final VWorldRegionClient vWorldRegionClient;
+    private final RegionCommandService regionCommandService;
+    private final RegionFindService regionFindService;
+
+    @EventListener(ApplicationReadyEvent.class)
+    @Transactional
+    public void initRegions() {
+        if (regionFindService.findRegionCount() > 0) {
+            log.info("이미 지역 데이터가 존재합니다.");
+            return;
+        }
+
+        log.info("행정구역 데이터 초기화 시작");
+
+        initSido();
+        initSigungu();
+        initDong();
+        initRee();
+
+        log.info("행정구역 데이터 초기화 완료");
+    }
+
+    @Transactional
+    public void initSido() {
+        initRegionLevel(
+                RegionLevel.SIDO,
+                null
+        );
+    }
+
+    @Transactional
+    public void initSigungu() {
+        initRegionLevel(
+                RegionLevel.SIGUNGU,
+                RegionLevel.SIDO
+        );
+    }
+
+    @Transactional
+    public void initDong() {
+        initRegionLevel(
+                RegionLevel.EMD,
+                RegionLevel.SIGUNGU
+        );
+    }
+
+    @Transactional
+    public void initRee() {
+        initRegionLevel(
+                RegionLevel.REE,
+                RegionLevel.EMD
+        );
+    }
+
+    private void initRegionLevel(RegionLevel level, RegionLevel parentLevel) {
+        log.info("{} 데이터 초기화 시작", level.getDescription());
+
+        List<VWorldRegionItem> items;
+
+        if (parentLevel == null) {
+            items = vWorldRegionClient.fetchSidos();
+        } else {
+            List<RegionEntity> parentRegions = regionFindService.findRegions(parentLevel);
+            if (parentRegions.isEmpty()) {
+                log.warn("{} 데이터가 없습니다. 먼저 {} 데이터를 초기화해주세요.",
+                        parentLevel.getDescription(), parentLevel.getDescription());
+                return;
+            }
+
+            items = fetchChildRegions(level, parentRegions);
+        }
+
+        int count = saveRegionsWithParent(items, level, parentLevel);
+        log.info("{} 데이터 {}건 저장 완료", level.getDescription(), count);
+    }
+
+    private List<VWorldRegionItem> fetchChildRegions(RegionLevel level, List<RegionEntity> parentRegions) {
+        List<VWorldRegionItem> result = new ArrayList<>();
+        int count = 0;
+        int total = parentRegions.size();
+
+        for (RegionEntity parent : parentRegions) {
+            count++;
+            try {
+                List<VWorldRegionItem> temp = fetchChildRegionsByLevel(level, parent.getCode());
+
+                if (temp != null && !temp.isEmpty()) {
+                    result.addAll(temp);
+                    log.debug("{} 하위 데이터 {}건 조회 (code: {})",
+                            parent.getName(), temp.size(), parent.getCode());
+                } else {
+                    log.debug("{} 하위 데이터 없음 (code: {})",
+                            parent.getName(), parent.getCode());
+                }
+
+                Thread.sleep(100);
+
+            } catch (Exception e) {
+                if (e instanceof InterruptedException) {
+                    Thread.currentThread().interrupt();
+                    log.warn("{} 조회 중 인터럽트 발생 ({}번째, code: {})", parent.getName(), count, parent.getCode());
+                    break;
+                }
+
+                log.warn("{} 조회 실패 ({}번째, code: {}): {}",
+                        parent.getName(), count, parent.getCode(), e.getMessage());
+            }
+        }
+
+        log.info("총 {}건 수집 완료 ({}/{}개 지역 조회)", result.size(), count, total);
+        return result;
+    }
+
+    private List<VWorldRegionItem> fetchChildRegionsByLevel(RegionLevel level, String parentCode) {
+        return switch (level) {
+            case SIGUNGU -> vWorldRegionClient.fetchSigungus(parentCode);
+            case EMD -> vWorldRegionClient.fetchEmds(parentCode);
+            case REE -> vWorldRegionClient.fetchRees(parentCode);
+            case SIDO -> throw new IllegalArgumentException("SIDO는 하위 지역 조회 대상이 아닙니다.");
+        };
+    }
+
+    private int saveRegionsWithParent(List<VWorldRegionItem> regionInfos, RegionLevel level, RegionLevel parentLevel) {
+        if (regionInfos.isEmpty()) {
+            log.warn("저장할 데이터가 없습니다.");
+            return 0;
+        }
+
+        Map<String, RegionEntity> parentMap = new HashMap<>();
+        if (parentLevel != null) {
+            List<RegionEntity> parents = regionFindService.findRegions(parentLevel);
+            parents.forEach(parent -> parentMap.put(parent.getCode(), parent));
+        }
+
+        List<RegionEntity> entities = regionInfos.stream()
+                .map(info -> {
+                    String parentCode = getParentCode(info.getAdmCode(), level);
+                    RegionEntity parent = parentCode != null ? parentMap.get(parentCode) : null;
+                    return toEntity(info, level, parent);
+                })
+                .toList();
+
+        List<RegionEntity> savedRegions = regionCommandService.saveAll(entities);
+        return savedRegions.size();
+    }
+
+    private String getParentCode(String admCode, RegionLevel level) {
+        if (admCode == null) return null;
+
+        return switch (level) {
+            case SIDO -> null;
+            case SIGUNGU -> admCode.substring(0, 2);
+            case EMD -> admCode.substring(0, 5);
+            case REE -> admCode.substring(0, 8);
+        };
+    }
+
+    private RegionEntity toEntity(VWorldRegionItem item, RegionLevel level, RegionEntity parent) {
+        String rawName = item.getAdmCodeNm() != null ? item.getAdmCodeNm() : item.getLowestAdmCodeNm();
+        String parsedName = extractLastName(rawName);
+
+        return RegionEntity.builder()
+                .code(item.getAdmCode())
+                .name(parsedName)
+                .fullName(rawName)
+                .level(level)
+                .parent(parent)
+                .build();
+    }
+
+    private String extractLastName(String fullName) {
+        if (fullName == null || fullName.isBlank()) return fullName;
+
+        String[] parts = fullName.trim().split("\\s+");
+        return parts[parts.length - 1];
+    }
+}

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -12,9 +12,9 @@ VALUES
 (2, 2, 'fcm_token_sample_admin', NOW(), NOW());
 
 -- 3. 지역 데이터 먼저 삽입 (ID: 1, 2, 3...)
-INSERT INTO region (id, name, parent_id, level) VALUES (1, '서울', NULL, 'SIDO');
-INSERT INTO region (id, name, parent_id, level) VALUES (2, '부산', NULL, 'SIDO');
-INSERT INTO region (id, name, parent_id, level) VALUES (3, '제주', NULL, 'SIDO');
+INSERT INTO region (id, code, name, full_name, parent_id, level) VALUES (1, '11', '서울특별시', '서울특별시', NULL, 'SIDO');
+INSERT INTO region (id, code, name, full_name, parent_id, level) VALUES (2, '26', '부산광역시', '부산광역시', NULL, 'SIDO');
+INSERT INTO region (id, code, name, full_name, parent_id, level) VALUES (3, '50', '제주특별자치도', '제주특별자치도', NULL, 'SIDO');
 
 -- 4. 카테고리 데이터
 INSERT INTO category_entity (id, code, name, icon_url) VALUES

--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -33,7 +33,9 @@ DROP TABLE IF EXISTS region;
 CREATE TABLE region
 (
     id        bigint PRIMARY KEY,
+    code      varchar(255) NOT NULL UNIQUE,
     name      varchar(100) NOT NULL,
+    full_name varchar(200) NOT NULL,
     parent_id bigint,
     level     varchar(20)  NOT NULL
 );


### PR DESCRIPTION
## 🚨 관련 이슈


## 🚀 작업 목적
- 브이월드 OpenAPI를 통해 행정구역 데이터를 가져와 `RegionEntity` 기준 데이터로 초기 적재할 수 있도록 구현했습니다.  
- 애플리케이션 실행 시 지역 데이터가 비어 있으면 자동으로 초기화되도록 하여, 장소와 여행 도메인에서 지역 정보를 안정적으로 참조할 수 있게 했습니다.

## 📝 작업 내용

- 브이월드 지역 API 호출용 `VWorldRegionClient` 추가
- 시도, 시군구, 읍면동, 리 단위 행정구역 조회 로직 구현
- 브이월드 응답 DTO 추가
- `RegionEntity`에 `code`, `fullName`, `parent`, `level` 기반 계층형 지역 구조 반영
- 지역 데이터 저장/조회용 서비스 로직 추가
- 애플리케이션 실행 시 `region` 테이블이 비어 있으면 지역 데이터 자동 초기화
- 변경된 `RegionEntity` 구조에 맞춰 `schema.sql`, `data.sql` 수정


## 🖼️ 스크린샷 (선택 사항)

## ✅ 체크리스트
- [ ] 코드 컨벤션을 준수했나요?
- [ ] 불필요한 주석이나 로그를 제거했나요?
- [ ] 테스트를 통과했나요?
- [ ] 변경 사항에 대한 문서를 업데이트했나요?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 애플리케이션 시작 시 행정구역(시도·시군구·읍면동·법정리) 데이터를 외부에서 자동으로 조회·초기화

* **개선사항**
  * 외부 API 연동으로 계층형 지역 목록을 안정적으로 조회 가능
  * 지역 데이터 모델 확장으로 지역 코드 및 전체 지역명 저장 지원
  * 지역 조회·집계 기능 및 조회 예외 처리가 강화됨

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Chocobi25/Leafy/pull/97?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->