### PR TITLE
fix: 지역 데이터 누락으로 인한 로컬 서버 시작 실패 방지

### DIFF
--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -15,6 +15,9 @@ VALUES
 INSERT INTO region (id, code, name, full_name, parent_id, level) VALUES (1, '11', '서울특별시', '서울특별시', NULL, 'SIDO');
 INSERT INTO region (id, code, name, full_name, parent_id, level) VALUES (2, '26', '부산광역시', '부산광역시', NULL, 'SIDO');
 INSERT INTO region (id, code, name, full_name, parent_id, level) VALUES (3, '50', '제주특별자치도', '제주특별자치도', NULL, 'SIDO');
+INSERT INTO region (id, code, name, full_name, parent_id, level) VALUES (4, '11110', '종로구', '서울특별시 종로구', 1, 'SIGUNGU');
+INSERT INTO region (id, code, name, full_name, parent_id, level) VALUES (5, '11110101', '청운동', '서울특별시 종로구 청운동', 4, 'EMD');
+INSERT INTO region (id, code, name, full_name, parent_id, level) VALUES (6, '1111010100', '청운동리', '서울특별시 종로구 청운동 청운동리', 5, 'REE');
 
 -- 4. 카테고리 데이터
 INSERT INTO category_entity (id, code, name, icon_url) VALUES


### PR DESCRIPTION
## 🚨 관련 이슈


## 🚀 작업 목적
- 로컬 및 테스트 환경에서 서버 시작 시 Region 동기화 로직이 실행되며, REE 레벨 지역 seed 데이터가 없어 서버가 종료되는 문제를 방지합니다.

## 📝 작업 내용 
- data.sql에 SIGUNGU, EMD, REE 레벨의 임시 지역 데이터를 추가했습니다.
- Region 초기화 조건이 충족되도록 모든 지역 레벨의 seed 데이터를 보강했습니다.

## 🖼️ 스크린샷 (선택 사항)

## ✅ 체크리스트
- [ ] 코드 컨벤션을 준수했나요?
- [ ] 불필요한 주석이나 로그를 제거했나요?
- [ ] 테스트를 통과했나요?
- [ ] 변경 사항에 대한 문서를 업데이트했나요?