### PR TITLE
refactor: 여행 구간을 경로 후보 중심 구조로 변경

### DIFF
--- a/src/main/java/com/chocobi/leafy/trip/application/TripSegmentService.java
+++ b/src/main/java/com/chocobi/leafy/trip/application/TripSegmentService.java
@@ -14,11 +14,14 @@ import com.chocobi.leafy.trip.dto.response.TripPlaceResponse;
 import com.chocobi.leafy.trip.dto.TripSegmentDTO;
 import com.chocobi.leafy.trip.dto.TripSegmentRedisDto;
 import com.chocobi.leafy.trip.infra.TripFindService;
+import com.chocobi.leafy.trip.infra.TripRouteOptionCommandService;
 import com.chocobi.leafy.trip.infra.TripSegmentCommandService;
 import com.chocobi.leafy.trip.infra.TripSegmentFindService;
 import com.chocobi.leafy.trip.infra.entity.TripEntity;
 import com.chocobi.leafy.trip.infra.entity.TripPlaceEntity;
+import com.chocobi.leafy.trip.infra.entity.TripRouteOptionEntity;
 import com.chocobi.leafy.trip.infra.entity.TripSegmentEntity;
+import com.chocobi.leafy.trip.vo.TripTransport;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
@@ -39,6 +42,7 @@ import static com.chocobi.leafy.distance.service.DistanceUtils.regionToPoint;
 public class TripSegmentService {
     private final TripSegmentFindService tripSegmentFindService;
     private final TripSegmentCommandService tripSegmentCommandService;
+    private final TripRouteOptionCommandService tripRouteOptionCommandService;
     private final TripFindService tripFindService;
     private final RedisTemplate<String, Object> redisTemplate;
     private final CarDistanceService carDistanceService;
@@ -80,7 +84,6 @@ public class TripSegmentService {
             double distance = sections.get(i).getDistance();
             int durationInMinutes = Math.max(1, sections.get(i).getDuration() / 60); // 초 -> 분
             double carbonEmission = sections.get(i).getCarbonEmission();
-            double maxCarbonEmission = sections.get(i).getMaxCarbonEmission();
 
             TripSegmentRedisDto dto = TripSegmentRedisDto.builder()
                     .tripId(tripId)
@@ -89,8 +92,7 @@ public class TripSegmentService {
                     .transport(transport == null ? null : transport.toLowerCase())
                     .distance(distance)
                     .duration(durationInMinutes)
-                    .carbonEmitted(carbonEmission)
-                    .maxCarbonEmission(maxCarbonEmission)
+                    .carbonEmission(carbonEmission)
                     .build();
 
             tripSegmentDtos.add(dto);
@@ -131,6 +133,12 @@ public class TripSegmentService {
         if (tripPlaces == null || tripPlaces.size() < 2) return tripSegments;
 
         TripEntity trip = tripFindService.findTrip(tripId);
+        TripRouteOptionEntity routeOption = createRouteOptionFromSections(
+                trip,
+                transport,
+                sections,
+                false
+        );
 
         List<TripPlaceResponse> mutableTripPlaces = new ArrayList<>(tripPlaces);
         mutableTripPlaces.sort(tripPlaceRouteOrder());
@@ -143,19 +151,16 @@ public class TripSegmentService {
             double distance = sections.get(i).getDistance();
             int durationInMinutes = Math.max(1, sections.get(i).getDuration() / 60);
             double carbonEmission = sections.get(i).getCarbonEmission();
-            double maxCarbonEmission = sections.get(i).getMaxCarbonEmission();
             TripPlaceEntity startTripPlace = tripPlaceService.getTripPlaceById(startPlace.getTripPlaceId());
             TripPlaceEntity endTripPlace = tripPlaceService.getTripPlaceById(endPlace.getTripPlaceId());
 
             TripSegmentEntity tripSegment = TripSegmentEntity.builder()
-                    .trip(trip)
+                    .routeOption(routeOption)
                     .startTripPlace(startTripPlace)
                     .endTripPlace(endTripPlace)
-                    .transport(transport == null ? null : transport.toLowerCase())
                     .distance(distance)
                     .duration(durationInMinutes)
-                    .carbonEmitted(carbonEmission)
-                    .maxCarbonEmission(maxCarbonEmission)
+                    .carbonEmission(carbonEmission)
                     .build();
             tripSegments.add(tripSegment);
         }
@@ -174,40 +179,30 @@ public class TripSegmentService {
         String normalized = transport.toLowerCase();
         List<TripSegmentRedisDto> tripSegmentDtos = getTempTripSegments(tripId, normalized); // 임시 TripSegmentRedisDto를 불러와서
 
-        String otherTransport = normalized.equals("car") ? "public" : "car";
-        List<TripSegmentRedisDto> otherTripSegmentDtos = null;
+        tripSegmentCommandService.deleteAllByTrip(trip);
+        tripRouteOptionCommandService.deleteAllByTrip(trip);
 
-        try {
-            otherTripSegmentDtos = getTempTripSegments(tripId, otherTransport);
-        } catch (IllegalArgumentException e) {
-            // 다른 교통수단이 없을 수 있음 — 무시
-        }
+        TripRouteOptionEntity routeOption = tripRouteOptionCommandService.save(createRouteOptionFromRedisDtos(
+                trip,
+                normalized,
+                tripSegmentDtos,
+                true
+        ));
 
-        // 최종 선택된 교통수단으로 transport 값 업데이트 및 maxCarbonEmission 설정
         List<TripSegmentEntity> tripSegments = new ArrayList<>();
-        for (int i = 0; i < tripSegmentDtos.size(); i++) {
-            TripSegmentRedisDto dto = tripSegmentDtos.get(i);
+        for (TripSegmentRedisDto dto : tripSegmentDtos) {
             dto.setTransport(normalized);
 
-            // maxCarbonEmission 설정: 현재 교통수단과 다른 교통수단의 maxCarbonEmission 중 더 큰 값
-            double maxCarbon = dto.getMaxCarbonEmission();
-            if (otherTripSegmentDtos != null && i < otherTripSegmentDtos.size()) {
-                double otherMaxCarbon = otherTripSegmentDtos.get(i).getMaxCarbonEmission();
-                maxCarbon = Math.max(maxCarbon, otherMaxCarbon);
-            }
-            dto.setMaxCarbonEmission(maxCarbon);
-
             tripSegments.add(dto.toEntity(
+                    routeOption,
                     tripPlaceService.getTripPlaceById(dto.getStartTripPlaceId()),
                     tripPlaceService.getTripPlaceById(dto.getEndTripPlaceId())
             ));
         }
 
-        tripSegmentCommandService.deleteAllByTrip(trip);
         saveTripSegments(tripSegments); // DB에 저장
         trip.clearRouteStale();
         deleteTempTripSegments(tripId, normalized); // 임시 저장한 TripSegments를 삭제
-        deleteTempTripSegments(tripId, otherTransport);
     }
 
     /**
@@ -247,7 +242,7 @@ public class TripSegmentService {
                 .sum();
 
         double totalCarbonEmission = segments.stream()
-                .mapToDouble(TripSegmentRedisDto::getCarbonEmitted)
+                .mapToDouble(TripSegmentRedisDto::getCarbonEmission)
                 .sum();
 
         Map<String, Object> result = new HashMap<>();
@@ -318,7 +313,7 @@ public class TripSegmentService {
 
     @Transactional
     public List<TripSegmentDTO> getTripSegments(Long tripId) {
-        return tripSegmentFindService.findTripSegmentsByTripId(tripId).stream()
+        return tripSegmentFindService.findConfirmedTripSegmentsByTripId(tripId).stream()
                 .map(TripSegmentDTO::fromEntity)
                 .toList();
     }
@@ -326,6 +321,7 @@ public class TripSegmentService {
     @Transactional
     public void deleteTripSegments(TripEntity trip) {
         tripSegmentCommandService.deleteAllByTrip(trip);
+        tripRouteOptionCommandService.deleteAllByTrip(trip);
     }
 
     /**
@@ -463,5 +459,37 @@ public class TripSegmentService {
     private Comparator<TripPlaceResponse> tripPlaceRouteOrder() {
         return Comparator.comparing(TripPlaceResponse::getDayIndex)
                 .thenComparing(TripPlaceResponse::getVisitOrder);
+    }
+
+    private TripRouteOptionEntity createRouteOptionFromSections(
+            TripEntity trip,
+            String transport,
+            List<Section> sections,
+            boolean confirmed
+    ) {
+        return TripRouteOptionEntity.builder()
+                .trip(trip)
+                .transport(TripTransport.from(transport))
+                .totalDistance(sections.stream().mapToDouble(Section::getDistance).sum())
+                .totalDuration(sections.stream().mapToInt(section -> Math.max(1, section.getDuration() / 60)).sum())
+                .totalCarbonEmission(sections.stream().mapToDouble(Section::getCarbonEmission).sum())
+                .confirmed(confirmed)
+                .build();
+    }
+
+    private TripRouteOptionEntity createRouteOptionFromRedisDtos(
+            TripEntity trip,
+            String transport,
+            List<TripSegmentRedisDto> tripSegments,
+            boolean confirmed
+    ) {
+        return TripRouteOptionEntity.builder()
+                .trip(trip)
+                .transport(TripTransport.from(transport))
+                .totalDistance(tripSegments.stream().mapToDouble(TripSegmentRedisDto::getDistance).sum())
+                .totalDuration(tripSegments.stream().mapToInt(TripSegmentRedisDto::getDuration).sum())
+                .totalCarbonEmission(tripSegments.stream().mapToDouble(TripSegmentRedisDto::getCarbonEmission).sum())
+                .confirmed(confirmed)
+                .build();
     }
 }

--- a/src/main/java/com/chocobi/leafy/trip/dto/TripSegmentDTO.java
+++ b/src/main/java/com/chocobi/leafy/trip/dto/TripSegmentDTO.java
@@ -14,20 +14,18 @@ public class TripSegmentDTO {
     private String transport;
     private double distance;
     private int duration;
-    private double carbonEmitted;
-    private double maxCarbonEmission;
+    private double carbonEmission;
 
     public static TripSegmentDTO fromEntity(TripSegmentEntity tripSegment) {
         return new TripSegmentDTO(
                 tripSegment.getId(),
-                tripSegment.getTrip().getId(),
+                tripSegment.getRouteOption().getTrip().getId(),
                 tripSegment.getStartTripPlace().getPlace().getId(),
                 tripSegment.getEndTripPlace().getPlace().getId(),
-                tripSegment.getTransport(),
+                tripSegment.getRouteOption().getTransport().getCode(),
                 tripSegment.getDistance(),
                 tripSegment.getDuration(),
-                tripSegment.getCarbonEmitted(),
-                tripSegment.getMaxCarbonEmission()
+                tripSegment.getCarbonEmission()
         );
     }
 }

--- a/src/main/java/com/chocobi/leafy/trip/dto/TripSegmentRedisDto.java
+++ b/src/main/java/com/chocobi/leafy/trip/dto/TripSegmentRedisDto.java
@@ -1,6 +1,7 @@
 package com.chocobi.leafy.trip.dto;
 
 import com.chocobi.leafy.trip.infra.entity.TripPlaceEntity;
+import com.chocobi.leafy.trip.infra.entity.TripRouteOptionEntity;
 import com.chocobi.leafy.trip.infra.entity.TripSegmentEntity;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -25,23 +26,27 @@ public class TripSegmentRedisDto implements Serializable {
     private String transport;
     private double distance;
     private int duration; // 소요 시간 (분)
-    private double carbonEmitted;
-    private double maxCarbonEmission;
+    private double carbonEmission;
 
-    public TripSegmentEntity toEntity(TripPlaceEntity startTripPlace, TripPlaceEntity endTripPlace) {
+    public TripSegmentEntity toEntity(
+            TripRouteOptionEntity routeOption,
+            TripPlaceEntity startTripPlace,
+            TripPlaceEntity endTripPlace
+    ) {
         if (!startTripPlace.getTrip().getId().equals(endTripPlace.getTrip().getId())) {
             throw new IllegalArgumentException("출발/도착 여행지가 같은 여행에 속해야 합니다.");
         }
+        if (!routeOption.getTrip().getId().equals(startTripPlace.getTrip().getId())) {
+            throw new IllegalArgumentException("경로 후보와 여행지가 같은 여행에 속해야 합니다.");
+        }
 
         return TripSegmentEntity.builder()
-                .trip(startTripPlace.getTrip())
+                .routeOption(routeOption)
                 .startTripPlace(startTripPlace)
                 .endTripPlace(endTripPlace)
-                .transport(this.transport)
                 .distance(this.distance)
                 .duration(this.duration)
-                .carbonEmitted(this.carbonEmitted)
-                .maxCarbonEmission(this.maxCarbonEmission)
+                .carbonEmission(this.carbonEmission)
                 .build();
     }
 }

--- a/src/main/java/com/chocobi/leafy/trip/infra/TripRouteOptionCommandService.java
+++ b/src/main/java/com/chocobi/leafy/trip/infra/TripRouteOptionCommandService.java
@@ -1,0 +1,34 @@
+package com.chocobi.leafy.trip.infra;
+
+import com.chocobi.leafy.trip.infra.entity.TripEntity;
+import com.chocobi.leafy.trip.infra.entity.TripRouteOptionEntity;
+import com.chocobi.leafy.trip.infra.repository.TripRouteOptionRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class TripRouteOptionCommandService {
+    private final TripRouteOptionRepository tripRouteOptionRepository;
+
+    public TripRouteOptionEntity save(TripRouteOptionEntity tripRouteOption) {
+        return tripRouteOptionRepository.save(tripRouteOption);
+    }
+
+    public List<TripRouteOptionEntity> saveAll(List<TripRouteOptionEntity> tripRouteOptions) {
+        return tripRouteOptionRepository.saveAll(tripRouteOptions);
+    }
+
+    public void deleteAllByTrip(TripEntity trip) {
+        tripRouteOptionRepository.deleteAllByTrip(trip);
+    }
+
+    public void confirmOnly(TripRouteOptionEntity selectedRouteOption, List<TripRouteOptionEntity> routeOptions) {
+        routeOptions.forEach(TripRouteOptionEntity::unconfirm);
+        selectedRouteOption.confirm();
+    }
+}

--- a/src/main/java/com/chocobi/leafy/trip/infra/TripRouteOptionFindService.java
+++ b/src/main/java/com/chocobi/leafy/trip/infra/TripRouteOptionFindService.java
@@ -1,0 +1,38 @@
+package com.chocobi.leafy.trip.infra;
+
+import com.chocobi.leafy.global.exception.CustomException;
+import com.chocobi.leafy.trip.infra.entity.TripRouteOptionEntity;
+import com.chocobi.leafy.trip.infra.repository.TripRouteOptionRepository;
+import com.chocobi.leafy.trip.vo.TripError;
+import com.chocobi.leafy.trip.vo.TripTransport;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class TripRouteOptionFindService {
+    private final TripRouteOptionRepository tripRouteOptionRepository;
+
+    public TripRouteOptionEntity findTripRouteOption(Long routeOptionId) {
+        return tripRouteOptionRepository.findById(routeOptionId)
+                .orElseThrow(() -> new CustomException(TripError.TRIP_ROUTE_OPTION_NOT_FOUND));
+    }
+
+    public List<TripRouteOptionEntity> findTripRouteOptions(Long tripId) {
+        return tripRouteOptionRepository.findAllByTrip_Id(tripId);
+    }
+
+    public TripRouteOptionEntity findTripRouteOption(Long tripId, String transport) {
+        return tripRouteOptionRepository.findByTrip_IdAndTransport(tripId, TripTransport.from(transport))
+                .orElseThrow(() -> new CustomException(TripError.TRIP_ROUTE_OPTION_NOT_FOUND));
+    }
+
+    public TripRouteOptionEntity findConfirmedTripRouteOption(Long tripId) {
+        return tripRouteOptionRepository.findByTrip_IdAndConfirmedTrue(tripId)
+                .orElseThrow(() -> new CustomException(TripError.TRIP_ROUTE_OPTION_NOT_FOUND));
+    }
+}

--- a/src/main/java/com/chocobi/leafy/trip/infra/TripSegmentCommandService.java
+++ b/src/main/java/com/chocobi/leafy/trip/infra/TripSegmentCommandService.java
@@ -1,6 +1,7 @@
 package com.chocobi.leafy.trip.infra;
 
 import com.chocobi.leafy.trip.infra.entity.TripEntity;
+import com.chocobi.leafy.trip.infra.entity.TripRouteOptionEntity;
 import com.chocobi.leafy.trip.infra.entity.TripSegmentEntity;
 import com.chocobi.leafy.trip.infra.repository.TripSegmentRepository;
 import lombok.RequiredArgsConstructor;
@@ -28,6 +29,10 @@ public class TripSegmentCommandService {
     }
 
     public void deleteAllByTrip(TripEntity tripEntity) {
-        tripSegmentRepository.deleteAllByTrip(tripEntity);
+        tripSegmentRepository.deleteAllByRouteOption_Trip_Id(tripEntity.getId());
+    }
+
+    public void deleteAllByRouteOption(TripRouteOptionEntity routeOption) {
+        tripSegmentRepository.deleteAllByRouteOption(routeOption);
     }
 }

--- a/src/main/java/com/chocobi/leafy/trip/infra/TripSegmentFindService.java
+++ b/src/main/java/com/chocobi/leafy/trip/infra/TripSegmentFindService.java
@@ -22,6 +22,14 @@ public class TripSegmentFindService {
     }
 
     public List<TripSegmentEntity> findTripSegmentsByTripId(Long tripId) {
-        return tripSegmentRepository.findByTrip_Id(tripId);
+        return tripSegmentRepository.findByRouteOption_Trip_Id(tripId);
+    }
+
+    public List<TripSegmentEntity> findTripSegmentsByRouteOptionId(Long routeOptionId) {
+        return tripSegmentRepository.findByRouteOption_Id(routeOptionId);
+    }
+
+    public List<TripSegmentEntity> findConfirmedTripSegmentsByTripId(Long tripId) {
+        return tripSegmentRepository.findByRouteOption_Trip_IdAndRouteOption_ConfirmedTrue(tripId);
     }
 }

--- a/src/main/java/com/chocobi/leafy/trip/infra/entity/TripRouteOptionEntity.java
+++ b/src/main/java/com/chocobi/leafy/trip/infra/entity/TripRouteOptionEntity.java
@@ -1,0 +1,56 @@
+package com.chocobi.leafy.trip.infra.entity;
+
+import com.chocobi.leafy.global.entity.BaseEntity;
+import com.chocobi.leafy.trip.vo.TripTransport;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Table(name = "trip_route_option")
+public class TripRouteOptionEntity extends BaseEntity {
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "trip_id", nullable = false)
+    private TripEntity trip;
+
+    @Column(name = "transport", nullable = false, length = 50)
+    @Enumerated(EnumType.STRING)
+    private TripTransport transport;
+
+    @Column(name = "total_distance", nullable = false)
+    private double totalDistance;
+
+    @Column(name = "total_duration", nullable = false)
+    private int totalDuration;
+
+    @Column(name = "total_carbon_emission", nullable = false)
+    private double totalCarbonEmission;
+
+    @Column(name = "recommended", nullable = false)
+    @Builder.Default
+    private boolean recommended = false;
+
+    @Column(name = "confirmed", nullable = false)
+    @Builder.Default
+    private boolean confirmed = false;
+
+    public void recommend() {
+        this.recommended = true;
+    }
+
+    public void unrecommend() {
+        this.recommended = false;
+    }
+
+    public void confirm() {
+        this.confirmed = true;
+    }
+
+    public void unconfirm() {
+        this.confirmed = false;
+    }
+}

--- a/src/main/java/com/chocobi/leafy/trip/infra/entity/TripSegmentEntity.java
+++ b/src/main/java/com/chocobi/leafy/trip/infra/entity/TripSegmentEntity.java
@@ -13,8 +13,8 @@ import lombok.*;
 public class TripSegmentEntity extends BaseEntity {
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "trip_id", nullable = false)
-    private TripEntity trip;
+    @JoinColumn(name = "route_option_id", nullable = false)
+    private TripRouteOptionEntity routeOption;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "start_trip_place_id", nullable = false)
@@ -24,18 +24,12 @@ public class TripSegmentEntity extends BaseEntity {
     @JoinColumn(name = "end_trip_place_id", nullable = false)
     private TripPlaceEntity endTripPlace;
 
-    @Column(name = "transport", nullable = false, length = 50)
-    private String transport;
-
     @Column(name = "distance", nullable = false)
     private double distance;
 
     @Column(name = "duration", nullable = false)
     private int duration; // 소요 시간 (분)
 
-    @Column(name = "carbon_emitted", nullable = false)
-    private double carbonEmitted;
-
-    @Column(name = "max_carbon_emission", nullable = false)
-    private double maxCarbonEmission;
+    @Column(name = "carbon_emission", nullable = false)
+    private double carbonEmission;
 }

--- a/src/main/java/com/chocobi/leafy/trip/infra/repository/TripRouteOptionRepository.java
+++ b/src/main/java/com/chocobi/leafy/trip/infra/repository/TripRouteOptionRepository.java
@@ -1,0 +1,22 @@
+package com.chocobi.leafy.trip.infra.repository;
+
+import com.chocobi.leafy.trip.infra.entity.TripEntity;
+import com.chocobi.leafy.trip.infra.entity.TripRouteOptionEntity;
+import com.chocobi.leafy.trip.vo.TripTransport;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+public interface TripRouteOptionRepository extends JpaRepository<TripRouteOptionEntity, Long> {
+
+    List<TripRouteOptionEntity> findAllByTrip_Id(Long tripId);
+
+    Optional<TripRouteOptionEntity> findByTrip_IdAndTransport(Long tripId, TripTransport transport);
+
+    Optional<TripRouteOptionEntity> findByTrip_IdAndConfirmedTrue(Long tripId);
+
+    void deleteAllByTrip(TripEntity trip);
+}

--- a/src/main/java/com/chocobi/leafy/trip/infra/repository/TripSegmentRepository.java
+++ b/src/main/java/com/chocobi/leafy/trip/infra/repository/TripSegmentRepository.java
@@ -1,6 +1,6 @@
 package com.chocobi.leafy.trip.infra.repository;
 
-import com.chocobi.leafy.trip.infra.entity.TripEntity;
+import com.chocobi.leafy.trip.infra.entity.TripRouteOptionEntity;
 import com.chocobi.leafy.trip.infra.entity.TripSegmentEntity;
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -10,7 +10,16 @@ import java.util.List;
 
 @Repository
 public interface TripSegmentRepository extends JpaRepository<TripSegmentEntity, Long> {
-    @EntityGraph(attributePaths = {"trip", "startTripPlace.place", "endTripPlace.place"})
-    List<TripSegmentEntity> findByTrip_Id(Long tripId);
-    void deleteAllByTrip(TripEntity trip);
+    @EntityGraph(attributePaths = {"routeOption.trip", "startTripPlace.place", "endTripPlace.place"})
+    List<TripSegmentEntity> findByRouteOption_Id(Long routeOptionId);
+
+    @EntityGraph(attributePaths = {"routeOption.trip", "startTripPlace.place", "endTripPlace.place"})
+    List<TripSegmentEntity> findByRouteOption_Trip_Id(Long tripId);
+
+    @EntityGraph(attributePaths = {"routeOption.trip", "startTripPlace.place", "endTripPlace.place"})
+    List<TripSegmentEntity> findByRouteOption_Trip_IdAndRouteOption_ConfirmedTrue(Long tripId);
+
+    void deleteAllByRouteOption(TripRouteOptionEntity routeOption);
+
+    void deleteAllByRouteOption_Trip_Id(Long tripId);
 }

--- a/src/main/java/com/chocobi/leafy/trip/vo/TripError.java
+++ b/src/main/java/com/chocobi/leafy/trip/vo/TripError.java
@@ -10,6 +10,7 @@ import org.springframework.http.HttpStatus;
 public enum TripError implements ErrorCode {
     TRIP_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 여행입니다."),
     TRIP_SEGMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 여행 경로입니다."),
+    TRIP_ROUTE_OPTION_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 여행 경로 후보입니다."),
     INVALID_TRIP_REQUEST(HttpStatus.BAD_REQUEST, "여행 요청 정보가 올바르지 않습니다."),
     INVALID_TRIP_TITLE(HttpStatus.BAD_REQUEST, "여행 제목을 입력해주세요."),
     INVALID_TRIP_DATE(HttpStatus.BAD_REQUEST, "여행 날짜가 올바르지 않습니다."),

--- a/src/main/java/com/chocobi/leafy/trip/vo/TripTransport.java
+++ b/src/main/java/com/chocobi/leafy/trip/vo/TripTransport.java
@@ -1,0 +1,31 @@
+package com.chocobi.leafy.trip.vo;
+
+import java.util.Locale;
+
+public enum TripTransport {
+    CAR("car"),
+    PUBLIC("public");
+
+    private final String code;
+
+    TripTransport(String code) {
+        this.code = code;
+    }
+
+    public String getCode() {
+        return code;
+    }
+
+    public static TripTransport from(String transport) {
+        if (transport == null) {
+            throw new IllegalArgumentException("transport가 필요합니다.");
+        }
+
+        String normalized = transport.toLowerCase(Locale.ROOT);
+        return switch (normalized) {
+            case "car", "자동차" -> CAR;
+            case "public", "public_trans", "bus", "대중교통" -> PUBLIC;
+            default -> throw new IllegalArgumentException("지원하지 않는 교통수단입니다: " + transport);
+        };
+    }
+}

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -60,6 +60,10 @@ VALUES
 (2, 2, 1, 0, 2, '바다 보러 가기');
 
 -- 11. 여행 구간 정보 (Trip Segment)
-INSERT INTO trip_segment (id, trip_id, start_trip_place_id, end_trip_place_id, distance, duration, carbon_emitted, max_carbon_emission, transport, created_at, updated_at)
+INSERT INTO trip_route_option (id, trip_id, transport, total_distance, total_duration, total_carbon_emission, recommended, confirmed, created_at, updated_at)
 VALUES
-(1, 1, 1, 2, 5.2, 20, 1.2, 2.0, 'BUS', NOW(), NOW());
+(1, 1, 'PUBLIC', 5.2, 20, 1.2, true, true, NOW(), NOW());
+
+INSERT INTO trip_segment (id, route_option_id, start_trip_place_id, end_trip_place_id, distance, duration, carbon_emission, created_at, updated_at)
+VALUES
+(1, 1, 1, 2, 5.2, 20, 1.2, NOW(), NOW());

--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -131,7 +131,8 @@ CREATE TABLE trip_route_option
     recommended             boolean NOT NULL DEFAULT false,
     confirmed               boolean NOT NULL DEFAULT false,
     created_at              datetime(6) NOT NULL,
-    updated_at              datetime(6) NOT NULL
+    updated_at              datetime(6) NOT NULL,
+    CONSTRAINT uq_trip_route_option_trip_transport UNIQUE (trip_id, transport)
 );
 
 DROP TABLE IF EXISTS trip_segment;
@@ -139,8 +140,8 @@ CREATE TABLE trip_segment
 (
     id              bigint PRIMARY KEY,
     route_option_id bigint NOT NULL,
-    start_trip_place_id  bigint,
-    end_trip_place_id    bigint,
+    start_trip_place_id  bigint NOT NULL,
+    end_trip_place_id    bigint NOT NULL,
     distance        double NOT NULL,
     duration        int NOT NULL,
     carbon_emission  double NOT NULL,

--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -119,18 +119,31 @@ CREATE TABLE trip_place
     memo            varchar(255)
 );
 
+DROP TABLE IF EXISTS trip_route_option;
+CREATE TABLE trip_route_option
+(
+    id                      bigint PRIMARY KEY,
+    trip_id                 bigint NOT NULL,
+    transport               enum('CAR','PUBLIC') NOT NULL,
+    total_distance          double NOT NULL,
+    total_duration          int NOT NULL,
+    total_carbon_emission   double NOT NULL,
+    recommended             boolean NOT NULL DEFAULT false,
+    confirmed               boolean NOT NULL DEFAULT false,
+    created_at              datetime(6) NOT NULL,
+    updated_at              datetime(6) NOT NULL
+);
+
 DROP TABLE IF EXISTS trip_segment;
 CREATE TABLE trip_segment
 (
     id              bigint PRIMARY KEY,
-    trip_id         bigint,
+    route_option_id bigint NOT NULL,
     start_trip_place_id  bigint,
     end_trip_place_id    bigint,
     distance        double NOT NULL,
     duration        int NOT NULL,
-    carbon_emitted  double,
-    max_carbon_emission double,
-    transport       varchar(255),
+    carbon_emission  double NOT NULL,
     created_at  datetime(6) NOT NULL,
     updated_at  datetime(6) NOT NULL
 );


### PR DESCRIPTION
## 🚨 관련 이슈
- #89 

## 🚀 작업 목적
TripSegment가 Trip과 교통수단을 직접 관리하던 구조를 TripRouteOption 중심 구조로 변경하기 위한 1차 리팩토링입니다.

## 📝 작업 내용 
- TripRouteOption 엔티티, Repository, Find/CommandService 추가
- TripSegment가 Trip 대신 TripRouteOption을 참조하도록 변경
- TripSegment의 transport 필드를 TripRouteOption으로 이동
- TripRouteOption transport를 TripTransport enum으로 관리
- TripSegment의 탄소 배출량 필드명을 carbonEmission으로 정리
- maxCarbonEmission 필드 제거
- TripSegmentRepository 조회 기준을 TripRouteOption 중심으로 변경
- schema.sql, data.sql에 TripRouteOption 구조 반영

이번 PR의 주요 리뷰 범위는 Entity, Repository, schema 변경입니다.
TripSegmentService의 Redis 기반 흐름 제거와 후보 계산/확정 API 변경은 후속 PR에서 진행할 예정입니다.

## 🖼️ 스크린샷 (선택 사항)

## ✅ 체크리스트
- [x] 코드 컨벤션을 준수했나요?
- [x] 불필요한 주석이나 로그를 제거했나요?
- [x] 테스트를 통과했나요?
- [x] 변경 사항에 대한 문서를 업데이트했나요?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 여행 경로 옵션에 대한 권장/확정 상태 관리 기능 추가
  * 교통수단별 여행 경로 옵션 선택 및 저장 기능 강화

* **개선사항**
  * 탄소 배출량 추적 단일화로 여행 경로 비교 분석 개선
  * 여행 구간 관리 구조 개선으로 데이터 일관성 강화

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Chocobi25/Leafy/pull/100?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->