### PR TITLE
feat: 국문 관광정보 API 연동 추가

### DIFF
--- a/src/main/java/com/chocobi/leafy/external/tour/client/TourKoreanInfoClient.java
+++ b/src/main/java/com/chocobi/leafy/external/tour/client/TourKoreanInfoClient.java
@@ -1,0 +1,122 @@
+package com.chocobi.leafy.external.tour.client;
+
+import com.chocobi.leafy.external.tour.dto.TourKoreanAreaBasedResponse;
+import com.chocobi.leafy.external.tour.dto.TourKoreanDetailImageResponse;
+import com.chocobi.leafy.external.tour.dto.TourKoreanPlaceDetailResponse;
+import com.chocobi.leafy.external.tour.dto.TourKoreanPlaceSearchCondition;
+import java.time.Duration;
+import java.util.Objects;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.client.WebClient;
+import org.springframework.web.util.UriBuilder;
+
+@Component
+@RequiredArgsConstructor
+public class TourKoreanInfoClient {
+    private static final String AREA_BASED_PATH = "/KorService2/areaBasedList2";
+    private static final String PLACE_DETAIL_PATH = "/KorService2/detailCommon2";
+    private static final String DETAIL_IMAGE_PATH = "/KorService2/detailImage2";
+    private static final int DEFAULT_NUM_OF_ROWS = 100;
+    private static final int DEFAULT_PAGE_NO = 1;
+    private static final String MOBILE_OS = "ETC";
+    private static final String MOBILE_APP = "Leafy";
+    private static final String RESPONSE_TYPE_JSON = "json";
+    private static final String ARRANGE_MODIFIED_DESC = "Q";
+    private static final String IMAGE_YN = "Y";
+    private static final String SUB_IMAGE_YN = "Y";
+    private static final Duration REQUEST_TIMEOUT = Duration.ofSeconds(10);
+
+    private final WebClient tourWebClient;
+
+    @Value("${tour.api.key}")
+    private String tourApiKey;
+
+    public TourKoreanAreaBasedResponse fetchAreaBasedPlaces(
+            TourKoreanPlaceSearchCondition condition,
+            int pageNo,
+            int numOfRows
+    ) {
+        return tourWebClient.get()
+                .uri(uriBuilder -> {
+                    UriBuilder builder = baseListUri(uriBuilder, AREA_BASED_PATH, pageNo, numOfRows)
+                            .queryParam("arrange", ARRANGE_MODIFIED_DESC);
+                    addPlaceSearchCondition(builder, condition);
+                    return builder.build();
+                })
+                .retrieve()
+                .bodyToMono(TourKoreanAreaBasedResponse.class)
+                .block(REQUEST_TIMEOUT);
+    }
+
+    public TourKoreanPlaceDetailResponse fetchPlaceDetail(String contentId, Integer contentTypeId) {
+        return tourWebClient.get()
+                .uri(uriBuilder -> baseUri(uriBuilder, PLACE_DETAIL_PATH)
+                        .queryParam("contentId", contentId)
+                        .queryParamIfPresent("contentTypeId", java.util.Optional.ofNullable(contentTypeId))
+                        .queryParam("defaultYN", "Y")
+                        .queryParam("firstImageYN", "Y")
+                        .queryParam("areacodeYN", "Y")
+                        .queryParam("catcodeYN", "Y")
+                        .queryParam("addrinfoYN", "Y")
+                        .queryParam("mapinfoYN", "Y")
+                        .queryParam("overviewYN", "Y")
+                        .build())
+                .retrieve()
+                .bodyToMono(TourKoreanPlaceDetailResponse.class)
+                .block(REQUEST_TIMEOUT);
+    }
+
+    public TourKoreanDetailImageResponse fetchDetailImages(String contentId) {
+        return tourWebClient.get()
+                .uri(uriBuilder -> baseListUri(uriBuilder, DETAIL_IMAGE_PATH, DEFAULT_PAGE_NO, DEFAULT_NUM_OF_ROWS)
+                        .queryParam("contentId", contentId)
+                        .queryParam("imageYN", IMAGE_YN)
+                        .queryParam("subImageYN", SUB_IMAGE_YN)
+                        .build())
+                .retrieve()
+                .bodyToMono(TourKoreanDetailImageResponse.class)
+                .block(REQUEST_TIMEOUT);
+    }
+
+    private UriBuilder baseListUri(UriBuilder uriBuilder, String path, int pageNo, int numOfRows) {
+        return baseUri(uriBuilder, path)
+                .queryParam("pageNo", pageNo)
+                .queryParam("numOfRows", numOfRows);
+    }
+
+    private UriBuilder baseUri(UriBuilder uriBuilder, String path) {
+        return uriBuilder
+                .path(path)
+                .queryParam("serviceKey", tourApiKey)
+                .queryParam("MobileOS", MOBILE_OS)
+                .queryParam("MobileApp", MOBILE_APP)
+                .queryParam("_type", RESPONSE_TYPE_JSON);
+    }
+
+    private void addPlaceSearchCondition(UriBuilder builder, TourKoreanPlaceSearchCondition condition) {
+        if (condition == null) {
+            return;
+        }
+
+        addOptionalQueryParam(builder, "contentTypeId", condition.contentTypeId());
+        addOptionalQueryParam(builder, "areaCode", condition.areaCode());
+        addOptionalQueryParam(builder, "sigunguCode", condition.sigunguCode());
+        addOptionalQueryParam(builder, "lclsSystm1", condition.lclsSystm1());
+        addOptionalQueryParam(builder, "lclsSystm2", condition.lclsSystm2());
+        addOptionalQueryParam(builder, "lclsSystm3", condition.lclsSystm3());
+    }
+
+    private void addOptionalQueryParam(UriBuilder builder, String name, Object value) {
+        if (Objects.isNull(value)) {
+            return;
+        }
+
+        if (value instanceof String stringValue && stringValue.isBlank()) {
+            return;
+        }
+
+        builder.queryParam(name, value);
+    }
+}

--- a/src/main/java/com/chocobi/leafy/external/tour/dto/TourKoreanAreaBasedResponse.java
+++ b/src/main/java/com/chocobi/leafy/external/tour/dto/TourKoreanAreaBasedResponse.java
@@ -1,0 +1,41 @@
+package com.chocobi.leafy.external.tour.dto;
+
+import com.chocobi.leafy.external.common.dto.ExternalApiResponse;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+
+@Getter
+public class TourKoreanAreaBasedResponse {
+    @JsonProperty("response")
+    private ExternalApiResponse<TourKoreanAreaBasedItem> externalApiResponse;
+
+    @Getter
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public static class TourKoreanAreaBasedItem {
+        private String addr1;
+        private String addr2;
+        private String areacode;
+        private String booktour;
+        private String cat1;
+        private String cat2;
+        private String cat3;
+        private String contentid;
+        private String contenttypeid;
+        private String createdtime;
+        private String firstimage;
+        private String firstimage2;
+        private String cpyrhtDivCd;
+        private String mapx;
+        private String mapy;
+        private String mlevel;
+        private String modifiedtime;
+        private String sigungucode;
+        private String tel;
+        private String title;
+        private String zipcode;
+        private String lclsSystm1;
+        private String lclsSystm2;
+        private String lclsSystm3;
+    }
+}

--- a/src/main/java/com/chocobi/leafy/external/tour/dto/TourKoreanDetailImageResponse.java
+++ b/src/main/java/com/chocobi/leafy/external/tour/dto/TourKoreanDetailImageResponse.java
@@ -1,0 +1,23 @@
+package com.chocobi.leafy.external.tour.dto;
+
+import com.chocobi.leafy.external.common.dto.ExternalApiResponse;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+
+@Getter
+public class TourKoreanDetailImageResponse {
+    @JsonProperty("response")
+    private ExternalApiResponse<TourKoreanDetailImageItem> externalApiResponse;
+
+    @Getter
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public static class TourKoreanDetailImageItem {
+        private String contentid;
+        private String imgname;
+        private String originimgurl;
+        private String serialnum;
+        private String smallimageurl;
+        private String cpyrhtDivCd;
+    }
+}

--- a/src/main/java/com/chocobi/leafy/external/tour/dto/TourKoreanPlaceDetailResponse.java
+++ b/src/main/java/com/chocobi/leafy/external/tour/dto/TourKoreanPlaceDetailResponse.java
@@ -1,0 +1,44 @@
+package com.chocobi.leafy.external.tour.dto;
+
+import com.chocobi.leafy.external.common.dto.ExternalApiResponse;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+
+@Getter
+public class TourKoreanPlaceDetailResponse {
+    @JsonProperty("response")
+    private ExternalApiResponse<TourKoreanPlaceDetailItem> externalApiResponse;
+
+    @Getter
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public static class TourKoreanPlaceDetailItem {
+        private String addr1;
+        private String addr2;
+        private String areacode;
+        private String booktour;
+        private String cat1;
+        private String cat2;
+        private String cat3;
+        private String contentid;
+        private String contenttypeid;
+        private String createdtime;
+        private String firstimage;
+        private String firstimage2;
+        private String cpyrhtDivCd;
+        private String homepage;
+        private String mapx;
+        private String mapy;
+        private String mlevel;
+        private String modifiedtime;
+        private String overview;
+        private String sigungucode;
+        private String tel;
+        private String telname;
+        private String title;
+        private String zipcode;
+        private String lclsSystm1;
+        private String lclsSystm2;
+        private String lclsSystm3;
+    }
+}

--- a/src/main/java/com/chocobi/leafy/external/tour/dto/TourKoreanPlaceSearchCondition.java
+++ b/src/main/java/com/chocobi/leafy/external/tour/dto/TourKoreanPlaceSearchCondition.java
@@ -1,0 +1,11 @@
+package com.chocobi.leafy.external.tour.dto;
+
+public record TourKoreanPlaceSearchCondition(
+        Integer contentTypeId,
+        String areaCode,
+        String sigunguCode,
+        String lclsSystm1,
+        String lclsSystm2,
+        String lclsSystm3
+) {
+}


### PR DESCRIPTION
## 🚨 관련 이슈


## 🚀 작업 목적
외부 장소 동기화 소스를 한국관광공사 국문 관광정보 API 중심으로 전환하기 위해 연동을 추가합니다.

## 📝 작업 내용

- 국문 관광정보 API 호출을 담당하는 `TourKoreanInfoClient` 추가
- 장소 목록 조회, 장소 상세 조회, 이미지 조회 응답 DTO 추가
- 분류/지역 조건 기반 장소 검색을 위한 요청 조건 DTO 추가
- 기존 생태관광/이미지 검색 API를 대체할 수 있도록 `contentId` 기반 조회 구조 구성


## 🖼️ 스크린샷 (선택 사항)

## ✅ 체크리스트
- [ ] 코드 컨벤션을 준수했나요?
- [ ] 불필요한 주석이나 로그를 제거했나요?
- [ ] 테스트를 통과했나요?
- [ ] 변경 사항에 대한 문서를 업데이트했나요?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새 기능**
  * 한국 관광 정보 조회 기능이 추가되었습니다. 지역 기반 관광지 목록 조회, 관광지 상세 정보 조회, 관광지 이미지 조회 기능을 이용할 수 있습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->